### PR TITLE
Add grammar for links, link references, and images

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,11 +5,11 @@
 - [x] specs for `inlines/entities`
 - [x] specs for `inlines/code-spans`
 - [x] include grammar for raw html
-- [ ] grammar for `inlines/links`
-- [ ] grammar for `inlines/images`
+- [x] grammar for `inlines/links`
+- [x] grammar for `inlines/images`
 - [ ] grammar for `inlines/auto-links`
 - [ ] grammar for `inlines/line-breaks`
-- [ ] grammar for `blocks/links-references`
+- [x] grammar for `blocks/links-references`
 - [ ] finish specs for `inlines/emphasis`
 - [ ] scope test with default themes
   - [ ] Atom dark/light

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,11 +7,11 @@
 - [x] include grammar for raw html
 - [x] grammar for `inlines/links`
 - [x] grammar for `inlines/images`
-- [ ] grammar for `inlines/auto-links`
+- [x] grammar for `inlines/auto-links`
 - [ ] grammar for `inlines/line-breaks`
 - [x] grammar for `blocks/links-references`
 - [ ] finish specs for `inlines/emphasis`
-- [ ] scope test with default themes
+- [ ] visual test of scopes with default themes
   - [ ] Atom dark/light
   - [ ] base16 tomorrow dark/light
   - [ ] One dark/light

--- a/examples/autolinks.md
+++ b/examples/autolinks.md
@@ -1,0 +1,49 @@
+<!-- http://spec.commonmark.org/0.22/#autolinks -->
+
+<!-- http://spec.commonmark.org/0.22/#example-543 -->
+<http://foo.bar.baz>
+
+<!-- http://spec.commonmark.org/0.22/#example-544 -->
+<http://foo.bar.baz/test?q=hello&id=22&boolean>
+
+<!-- http://spec.commonmark.org/0.22/#example-545 -->
+<irc://foo.bar:2233/baz>
+
+<!-- http://spec.commonmark.org/0.22/#example-546 -->
+<MAILTO:FOO@BAR.BAZ>
+
+<!-- http://spec.commonmark.org/0.22/#example-547 -->
+<http://foo.bar/baz bim>
+
+<!-- http://spec.commonmark.org/0.22/#example-548 -->
+<http://example.com/\[\>
+
+<!-- http://spec.commonmark.org/0.22/#example-549 -->
+<foo@bar.example.com>
+
+<!-- http://spec.commonmark.org/0.22/#example-550 -->
+<foo+special@Bar.baz-bar0.com>
+
+<!-- http://spec.commonmark.org/0.22/#example-551 -->
+<foo\+@bar.example.com>
+
+<!-- http://spec.commonmark.org/0.22/#example-552 -->
+<>
+
+<!-- http://spec.commonmark.org/0.22/#example-553 -->
+<heck://bing.bong>
+
+<!-- http://spec.commonmark.org/0.22/#example-554 -->
+< http://foo.bar >
+
+<!-- http://spec.commonmark.org/0.22/#example-555 -->
+<foo.bar.baz>
+
+<!-- http://spec.commonmark.org/0.22/#example-556 -->
+<localhost:5001/foo>
+
+<!-- http://spec.commonmark.org/0.22/#example-557 -->
+http://example.com
+
+<!-- http://spec.commonmark.org/0.22/#example-558 -->
+foo@bar.example.com

--- a/examples/links.md
+++ b/examples/links.md
@@ -92,6 +92,7 @@ bar>)
 
 <!-- http://spec.commonmark.org/0.22/#example-469 -->
 [link *foo **bar** `#`*](/uri)
+[link _foo **bar** `#`_](/uri)
 
 # ----- BOOKMARK ----- #
 

--- a/grammars/markdown.cson
+++ b/grammars/markdown.cson
@@ -35,7 +35,7 @@ repository:
       { include: '#code' }
       { include: '#entities' }
       { include: '#links' }
-      { include: '#html' }
+      # { include: '#html' }
       { include: '#emphasis' }
       { include: '#github' }
       { include: '#criticmark' }
@@ -655,6 +655,31 @@ repository:
           1: patterns: [{ include: '#link-label' }]
           2: name: 'punctuation.md'
           3: patterns: [{ include: '#link-destination' }]
+      }
+
+      # auto-link: absolute uri
+      {
+        name: 'auto.link.md'
+        match: '(?i:(<)((coap|doi|javascript|aaa|aaas|about|acap|cap|cid|crid|data|dav|dict|dns|file|ftp|geo|go|gopher|h323|http|https|iax|icap|im|imap|info|ipp|iris|iris.beep|iris.xpc|iris.xpcs|iris.lwz|ldap|mailto|mid|msrp|msrps|mtqp|mupdate|news|nfs|ni|nih|nntp|opaquelocktoken|pop|pres|rtsp|service|session|shttp|sieve|sip|sips|sms|snmp|soap.beep|soap.beeps|tag|tel|telnet|tftp|thismessage|tn3270|tip|tv|urn|vemmi|ws|wss|xcon|xcon-userid|xmlrpc.beep|xmlrpc.beeps|xmpp|z39.50r|z39.50s|adiumxtra|afp|afs|aim|apt|attachment|aw|beshare|bitcoin|bolo|callto|chrome|chrome-extension|com-eventbrite-attendee|content|cvs|dlna-playsingle|dlna-playcontainer|dtn|dvb|ed2k|facetime|feed|finger|fish|gg|git|gizmoproject|gtalk|hcp|icon|ipn|irc|irc6|ircs|itms|jar|jms|keyparc|lastfm|ldaps|magnet|maps|market|message|mms|ms-help|msnim|mumble|mvn|notes|oid|palm|paparazzi|platform|proxy|psyc|query|res|resource|rmi|rsync|rtmp|secondlife|sftp|sgn|skype|smb|soldat|spotify|ssh|steam|svn|teamspeak|things|udp|unreal|ut2004|ventrilo|view-source|webcal|wtai|wyciwyg|xfire|xri|ymsgr):(?:[^ [:cntrl:]<>]+))(>))'
+        captures:
+          1: name: 'punctuation.md'
+          2: name: 'uri.underline.markup.md'
+          3: name: 'scheme.md'
+          4: name: 'punctuation.md'
+      }
+
+      # auto-link: email
+      {
+        name: 'email.auto.link.md'
+        match: '(<)(([a-zA-Z0-9\\.!#$%&\'\\*\\+/=?^_`{\\|}~-]+)(@)([a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*))(>)'
+        # match: '(<)([a-zA-Z0-9\\.*\\+_-]+)(@)(>)'
+        captures:
+          1: name: 'punctuation.md'
+          2: name: 'uri.underline.markup.md'
+          3: name: 'before-at.md'
+          4: name: 'punctuation.md'
+          5: name: 'after-at.md'
+          6: name: 'punctuation.md'
       }
 
     ]

--- a/grammars/markdown.cson
+++ b/grammars/markdown.cson
@@ -579,9 +579,10 @@ repository:
     patterns: [
 
       # [link](/uri "title")
+      # ![link](/uri "title")
       {
         name: 'link.md'
-        match: '((?:\\[)(?:[^\\]]*)(?:\\]))(\\()([^ [:cntrl:]]+) ((?:["\'\\(]).*?(?:["\'\\)]))(\\))'
+        match: '((?:!?\\[)(?:[^\\]]*)(?:\\]))(\\()([^ [:cntrl:]]+) ((?:["\'\\(]).*?(?:["\'\\)]))(\\))'
         captures:
           1: patterns: [{ include: '#link-text' }]
           2: name: 'punctuation.md'
@@ -592,9 +593,11 @@ repository:
 
       # [link]()
       # [link](/uri)
+      # ![link]()
+      # ![link](/uri)
       {
         name: 'link.md'
-        match: '((?:\\[)(?:[^\\]]*)(?:\\]))(\\()([^ [:cntrl:]]*)(\\))'
+        match: '((?:!?\\[)(?:[^\\]]*)(?:\\]))(\\()([^ [:cntrl:]]*)(\\))'
         captures:
           1: patterns: [{ include: '#link-text' }]
           2: name: 'punctuation.md'
@@ -604,9 +607,10 @@ repository:
 
       # NOTE Spaces in URI are allowed between < and >
       # [link](<>)
+      # ![link](<>)
       {
         name: 'link.md'
-        match: '((?:\\[)(?:[^\\]]*)(?:\\]))(\\()(<[^[:cntrl:]]*>)(\\))'
+        match: '((?:!?\\[)(?:[^\\]]*)(?:\\]))(\\()(<[^[:cntrl:]]*>)(\\))'
         captures:
           1: patterns: [{ include: '#link-text' }]
           2: name: 'punctuation.md'
@@ -615,12 +619,21 @@ repository:
       }
 
       # [foo][bar]
+      # ![foo][bar]
       {
         name: 'link.md'
-        match: '((?:\\[)(?:[^\\]]*)(?:\\]))((?:\\[)(?:[^\\]]*)(?:\\]))'
+        match: '((?:!?\\[)(?:[^\\]]*)(?:\\]))((?:\\[)(?:[^\\]]*)(?:\\]))'
         captures:
           1: patterns: [{ include: '#link-text' }]
           2: patterns: [{ include: '#link-label' }]
+      }
+
+      # ![image]
+      {
+        name: 'link.md'
+        match: '((?:!\\[)(?:[^\\]]*)(?:\\]))'
+        captures:
+          1: patterns: [{ include: '#link-text' }]
       }
 
       # [ref]: /uri "title"
@@ -677,6 +690,17 @@ repository:
 
   'link-text':
     patterns: [
+      {
+        name: 'image.link.string.md'
+        match: '^(!\\[)(.*)(\\])$'
+        captures:
+          1: name: 'punctuation.md'
+          2: patterns: [
+            { include: '#emphasis' }
+            { include: '#code' }
+          ]
+          3: name: 'punctuation.md'
+      }
       {
         name: 'text.link.string.md'
         match: '^(\\[)(.*)(\\])$'

--- a/grammars/markdown.cson
+++ b/grammars/markdown.cson
@@ -572,6 +572,7 @@ repository:
   #
   # inline
   # LINKS
+  # LINK REFERENCES
   #
 
   links:
@@ -613,21 +614,36 @@ repository:
           4: name: 'punctuation.md'
       }
 
-    ]
-
-  'link-text':
-    patterns: [
+      # [foo][bar]
       {
-        name: 'text.link.string.md'
-        match: '^(\\[)(.*)(\\])$'
+        name: 'link.md'
+        match: '((?:\\[)(?:[^\\]]*)(?:\\]))((?:\\[)(?:[^\\]]*)(?:\\]))'
         captures:
-          1: name: 'punctuation.md'
-          2: patterns: [
-            { include: '#emphasis' }
-            { include: '#code' }
-          ]
-          3: name: 'punctuation.md'
+          1: patterns: [{ include: '#link-text' }]
+          2: patterns: [{ include: '#link-label' }]
       }
+
+      # [ref]: /uri "title"
+      {
+        name: 'reference.link.md'
+        match: '((?:\\[)(?:[^\\]]*)(?:\\]))(:) ([^ [:cntrl:]]+) ((?:").*?(?:"))'
+        captures:
+          1: patterns: [{ include: '#link-label' }]
+          2: name: 'punctuation.md'
+          3: patterns: [{ include: '#link-destination' }]
+          4: patterns: [{ include: '#link-title' }]
+      }
+
+      # [ref]: /uri
+      {
+        name: 'reference.link.md'
+        match: '((?:\\[)(?:[^\\]]*)(?:\\]))(:) ([^ [:cntrl:]]+)'
+        captures:
+          1: patterns: [{ include: '#link-label' }]
+          2: name: 'punctuation.md'
+          3: patterns: [{ include: '#link-destination' }]
+      }
+
     ]
 
   'link-destination':
@@ -648,6 +664,32 @@ repository:
       }
     ]
 
+  'link-label':
+    patterns: [
+      {
+        name: 'label.link.string.md'
+        match: '^(\\[)(.*)(\\])$'
+        captures:
+          1: name: 'punctuation.md'
+          3: name: 'punctuation.md'
+      }
+    ]
+
+  'link-text':
+    patterns: [
+      {
+        name: 'text.link.string.md'
+        match: '^(\\[)(.*)(\\])$'
+        captures:
+          1: name: 'punctuation.md'
+          2: patterns: [
+            { include: '#emphasis' }
+            { include: '#code' }
+          ]
+          3: name: 'punctuation.md'
+      }
+    ]
+
   'link-title':
     patterns: [
       {
@@ -665,13 +707,6 @@ repository:
           3: name: 'punctuation.md'
       }
     ]
-
-  #
-  # block
-  # LINK REFERENCES
-  #
-
-  # TODO
 
   #
   # block

--- a/grammars/markdown.cson
+++ b/grammars/markdown.cson
@@ -576,63 +576,93 @@ repository:
 
   links:
     patterns: [
+
+      # [link](/uri "title")
       {
-        # (link)[</space uri>]
         name: 'link.md'
-        match: '((\\[)([^\\]]*?)(\\]))((\\()(<)(.*)(>)(\\)))'
+        match: '((?:\\[)(?:[^\\]]*)(?:\\]))(\\()([^ [:cntrl:]]+) ((?:["\'\\(]).*?(?:["\'\\)]))(\\))'
         captures:
-          1: name: 'text.link.string.md'
+          1: patterns: [{ include: '#link-text' }]
           2: name: 'punctuation.md'
-          3:
-            patterns: [
-              { include: '#inlines' }
-            ]
+          3: patterns: [{ include: '#link-destination' }]
+          4: patterns: [{ include: '#link-title' }]
+          5: name: 'punctuation.md'
+      }
+
+      # [link]()
+      # [link](/uri)
+      {
+        name: 'link.md'
+        match: '((?:\\[)(?:[^\\]]*)(?:\\]))(\\()([^ [:cntrl:]]*)(\\))'
+        captures:
+          1: patterns: [{ include: '#link-text' }]
+          2: name: 'punctuation.md'
+          3: patterns: [{ include: '#link-destination' }]
           4: name: 'punctuation.md'
-          5: name: 'destination.link.md'
-          6: name: 'punctuation.md'
-          7: name: 'punctuation.md'
-          8: name: 'uri.underline.markup.md'
-          9: name: 'punctuation.md'
-          10: name: 'punctuation.md'
+      }
+
+      # NOTE Spaces in URI are allowed between < and >
+      # [link](<>)
+      {
+        name: 'link.md'
+        match: '((?:\\[)(?:[^\\]]*)(?:\\]))(\\()(<[^[:cntrl:]]*>)(\\))'
+        captures:
+          1: patterns: [{ include: '#link-text' }]
+          2: name: 'punctuation.md'
+          3: patterns: [{ include: '#link-destination' }]
+          4: name: 'punctuation.md'
+      }
+
+    ]
+
+  'link-text':
+    patterns: [
+      {
+        name: 'text.link.string.md'
+        match: '^(\\[)(.*)(\\])$'
+        captures:
+          1: name: 'punctuation.md'
+          2: patterns: [
+            { include: '#emphasis' }
+            { include: '#code' }
+          ]
+          3: name: 'punctuation.md'
+      }
+    ]
+
+  'link-destination':
+    patterns: [
+      {
+        name: 'destination.link.md'
+        match: '^(<)(.*)(>)$'
+        captures:
+          1: name: 'punctuation.md'
+          2: name: 'uri.underline.markup.md'
+          3: name: 'punctuation.md'
       }
       {
-        # (link)[/uri "title"] or (link)[/uri 'title']
-        #
-        # NOTE title in parentheses not supported
-        name: 'link.md'
-        match: '((\\[)([^\\]]*?)(\\]))((\\()([^ ]*) ((["\'])(?:.+)(\\9))(\\)))'
+        name: 'destination.link.md'
+        match: '(.+)'
         captures:
-          1: name: 'text.link.string.md'
-          2: name: 'punctuation.md'
-          3:
-            patterns: [
-              { include: '#inlines' }
-            ]
-          4: name: 'punctuation.md'
-          5: name: 'destination.link.md'
-          6: name: 'punctuation.md'
-          7: name: 'uri.underline.markup.md'
-          8: name: 'title.link.heading.markup.md'
-          9: name: 'punctuation.md'
-          10: name: 'punctuation.md'
-          11: name: 'punctuation.md'
+          1: name: 'uri.underline.markup.md'
+      }
+    ]
+
+  'link-title':
+    patterns: [
+      {
+        name: 'title.link.md'
+        match: '^([\'|"])(.*)(\\1)$'
+        captures:
+          1: name: 'punctuation.md'
+          3: name: 'punctuation.md'
       }
       {
-        # (link)[/uri]
-        name: 'link.md'
-        match: '((\\[)([^\\]]*?)(\\]))((\\()(?!<)([^ ]*)(\\)))'
+        name: 'title.link.md'
+        match: '^(\\()(.*)(\\))$'
         captures:
-          1: name: 'text.link.string.md'
-          2: name: 'punctuation.md'
-          3:
-            patterns: [
-              { include: '#inlines' }
-            ]
-          4: name: 'punctuation.md'
-          5: name: 'destination.link.md'
-          6: name: 'punctuation.md'
-          7: name: 'uri.underline.markup.md'
-          8: name: 'punctuation.md'
+          1: name: 'punctuation.md'
+          3: name: 'punctuation.md'
       }
     ]
 

--- a/spec/fixtures/inlines/emphasis.ass
+++ b/spec/fixtures/inlines/emphasis.ass
@@ -506,11 +506,11 @@
           "bar"
           "]": punctuation.md
         }
-        destination.link.md {
-          "(": punctuation.md
-          "/url": uri.underline.markup.md
-          ")": punctuation.md
-        }
+        "(": punctuation.md
+          destination.link.md {
+            "/url": uri.underline.markup.md
+          }
+        ")": punctuation.md
       }
       "*": punctuation.md
     }
@@ -761,11 +761,11 @@
           "bar"
           "]": punctuation.md
         }
+        "(": punctuation.md
         destination.link.md {
-          "(": punctuation.md
           "/url": uri.underline.markup.md
-          ")": punctuation.md
         }
+        ")": punctuation.md
       }
       "**": punctuation.md
     }
@@ -964,11 +964,11 @@
           }
           "]": punctuation.md
         }
+        "(": punctuation.md
         destination.link.md {
-          "(": punctuation.md
           "/url": uri.underline.markup.md
-          ")": punctuation.md
         }
+        ")": punctuation.md
       }
       "**": punctuation.md
     }


### PR DESCRIPTION
After restructuring the grammar for links, implementing link references and images was a piece of cake. I'll write specs later, but from a quick visual check this already looks promising. I plan to include this PR when releasing `0.1` hopefully later today. Specs will be part of `0.2`.