### PR TITLE
Add include for Sass, SCSS

### DIFF
--- a/grammars/fixtures/fenced-code.cson
+++ b/grammars/fixtures/fenced-code.cson
@@ -54,7 +54,8 @@ list: [
   { pattern:'r' }
   { pattern:'ruby' }
   { pattern:'rust|rs', include:'source.rust' }
-  { pattern:'scss' }
+  { pattern:'sass' }
+  { pattern:'scss', include:'source.css.scss' }
   { pattern:'sh|bash', include:'source.shell' }
   { pattern:'sql' }
   { pattern:'swift' }

--- a/grammars/language-markdown.json
+++ b/grammars/language-markdown.json
@@ -2769,6 +2769,43 @@
           ]
         },
         {
+          "begin": "^\\s*([`~]{3,})\\s*(\\{?)((?:\\.?)(?:sass))(?=( |$))\\s*([^`\\}]*)(\\}?)$",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.md"
+            },
+            "2": {
+              "name": "punctuation.md"
+            },
+            "3": {
+              "name": "language.constant.md"
+            },
+            "5": {
+              "patterns": [
+                {
+                  "include": "#special-attribute-elements"
+                }
+              ]
+            },
+            "6": {
+              "name": "punctuation.md"
+            }
+          },
+          "end": "^\\s*(\\1)$",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.md"
+            }
+          },
+          "name": "fenced.code.md",
+          "contentName": "embedded.source.sass",
+          "patterns": [
+            {
+              "include": "source.sass"
+            }
+          ]
+        },
+        {
           "begin": "^\\s*([`~]{3,})\\s*(\\{?)((?:\\.?)(?:scss))(?=( |$))\\s*([^`\\}]*)(\\}?)$",
           "beginCaptures": {
             "1": {
@@ -2798,10 +2835,10 @@
             }
           },
           "name": "fenced.code.md",
-          "contentName": "embedded.source.scss",
+          "contentName": "embedded.source.css.scss",
           "patterns": [
             {
-              "include": "source.scss"
+              "include": "source.css.scss"
             }
           ]
         },


### PR DESCRIPTION
Added support for the Sass syntax, as well as fixed the include for SCSS, SCSS' scope is source.css.scss, not source.scss. I am not sure why it is this way.