### PR TITLE
Add spec for commands

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -102,8 +102,7 @@ module.exports =
                         if classes.indexOf('ordered') isnt -1
                           typeOfList = 'ordered'
                         if classes.indexOf('definition') isnt -1
-                          # Skip definition-lists
-                          isListItem = false
+                          typeOfList = 'definition'
                         break
 
                       else
@@ -115,7 +114,7 @@ module.exports =
                     else
                       isPunctuation = false
 
-                  if isListItem
+                  if isListItem and typeOfList isnt 'definition'
                     text = token.value
 
                     # increment ordered list-item

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -37,11 +37,11 @@ module.exports =
     @subscriptions = new CompositeDisposable()
 
     # Add commands to overwrite the behavior of tab within list-item context
-    @subscriptions.add atom.commands.add 'atom-workspace', 'markdown:indent-list-item': (event) => @indentListItem(event)
-    @subscriptions.add atom.commands.add 'atom-workspace', 'markdown:outdent-list-item': (event) => @outdentListItem(event)
+    @subscriptions.add atom.commands.add 'atom-text-editor', 'markdown:indent-list-item': (event) => @indentListItem(event)
+    @subscriptions.add atom.commands.add 'atom-text-editor', 'markdown:outdent-list-item': (event) => @outdentListItem(event)
 
     # Add command to toggle a task
-    @subscriptions.add atom.commands.add 'atom-workspace', 'markdown:toggle-task': (event) => @toggleTask(event)
+    @subscriptions.add atom.commands.add 'atom-text-editor', 'markdown:toggle-task': (event) => @toggleTask(event)
 
     # Disable language-gfm as this package is intended as its replacement
     if atom.config.get('language-markdown.disableLanguageGfm')

--- a/spec/ass-spec.coffee
+++ b/spec/ass-spec.coffee
@@ -1,106 +1,104 @@
-if false
+_ = require 'lodash'
+ASS = require 'lib-ass'
+{Directory} = require 'atom'
+fs = require 'fs'
+path = require 'path'
 
-  _ = require 'lodash'
-  ASS = require 'lib-ass'
-  {Directory} = require 'atom'
-  fs = require 'fs'
-  path = require 'path'
+# NOTE
+# Manually specify {fixtures} if you only want to run specific tests.
+# A {fixture} is a relative path + filename (without extension).
+# fixtures = [
+#   "flavors/github/task-lists"
+# ]
 
-  # NOTE
-  # Manually specify {fixtures} if you only want to run specific tests.
-  # A {fixture} is a relative path + filename (without extension).
-  # fixtures = [
-  #   "flavors/github/task-lists"
-  # ]
+# Automatically generate the {fixtures} array from the file system.
+# Include all .ass files found inside /spec/fixtures, by their relative path
+# but excluding the file extension. This {fixture} is used to generate
+# identifiers for tasks.
+unless fixtures
+  getFixturesFrom = (directoryPath = '') ->
+    results = []
+    directory = new Directory(path.join(__dirname, './fixtures' + directoryPath))
+    entries = directory.getEntriesSync()
+    for entry in entries
+      if entry.isFile()
+        filename = entry.getBaseName()
+        if filename.substr(-4) is '.ass'
+          fixture = directoryPath + "/" + filename.substr(0, filename.length - 4)
+          results.push fixture
+      else
+        results = results.concat(getFixturesFrom(directoryPath + "/" + entry.getBaseName()))
+    return results
 
-  # Automatically generate the {fixtures} array from the file system.
-  # Include all .ass files found inside /spec/fixtures, by their relative path
-  # but excluding the file extension. This {fixture} is used to generate
-  # identifiers for tasks.
-  unless fixtures
-    getFixturesFrom = (directoryPath = '') ->
-      results = []
-      directory = new Directory(path.join(__dirname, './fixtures' + directoryPath))
-      entries = directory.getEntriesSync()
-      for entry in entries
-        if entry.isFile()
-          filename = entry.getBaseName()
-          if filename.substr(-4) is '.ass'
-            fixture = directoryPath + "/" + filename.substr(0, filename.length - 4)
-            results.push fixture
+  fixtures = getFixturesFrom()
+
+describe "Markdown grammar", ->
+  grammar = null
+
+  beforeEach ->
+    waitsForPromise ->
+      atom.packages.activatePackage('language-markdown')
+
+    runs ->
+      grammar = atom.grammars.grammarForScopeName('text.md')
+
+  # Test the grammar
+  it "parses the grammar", ->
+    expect(grammar).toBeDefined()
+    expect(grammar.scopeName).toBe "text.md"
+
+  for fixture in fixtures
+
+    # Try to load the fixture
+    try
+      absolutePath = path.join(__dirname, "fixtures/#{fixture}.ass")
+      fileContents = fs.readFileSync(absolutePath, 'utf8')
+      ass = new ASS(fileContents)
+      tests = ass.getTests()
+    catch error
+      ass = null
+      tests = 0
+
+    # Test the basics of the fixture
+    it "should load #{absolutePath}", ->
+      expect(ass).not.toEqual(null)
+
+    it "should define at least one test", ->
+      expect(tests.length > 0).toEqual(true)
+
+    # Everything seems to be okay, let's run the tests
+    describe fixture, ->
+      grammar = null
+
+      beforeEach ->
+        waitsForPromise ->
+          atom.packages.activatePackage('language-markdown')
+
+        runs ->
+          grammar = atom.grammars.grammarForScopeName('text.md')
+
+      # Cycle through the tests we've created in ASS
+      # and we need to do it in a closure apparently
+      _.forEach tests, (test) ->
+
+        unless test.isValid
+          xit "should pass test: #{fixture}/#{test.id}", ->
+            return
         else
-          results = results.concat(getFixturesFrom(directoryPath + "/" + entry.getBaseName()))
-      return results
 
-    fixtures = getFixturesFrom()
-
-  describe "Markdown grammar", ->
-    grammar = null
-
-    beforeEach ->
-      waitsForPromise ->
-        atom.packages.activatePackage('language-markdown')
-
-      runs ->
-        grammar = atom.grammars.grammarForScopeName('text.md')
-
-    # Test the grammar
-    it "parses the grammar", ->
-      expect(grammar).toBeDefined()
-      expect(grammar.scopeName).toBe "text.md"
-
-    for fixture in fixtures
-
-      # Try to load the fixture
-      try
-        absolutePath = path.join(__dirname, "fixtures/#{fixture}.ass")
-        fileContents = fs.readFileSync(absolutePath, 'utf8')
-        ass = new ASS(fileContents)
-        tests = ass.getTests()
-      catch error
-        ass = null
-        tests = 0
-
-      # Test the basics of the fixture
-      it "should load #{absolutePath}", ->
-        expect(ass).not.toEqual(null)
-
-      it "should define at least one test", ->
-        expect(tests.length > 0).toEqual(true)
-
-      # Everything seems to be okay, let's run the tests
-      describe fixture, ->
-        grammar = null
-
-        beforeEach ->
-          waitsForPromise ->
-            atom.packages.activatePackage('language-markdown')
-
-          runs ->
-            grammar = atom.grammars.grammarForScopeName('text.md')
-
-        # Cycle through the tests we've created in ASS
-        # and we need to do it in a closure apparently
-        _.forEach tests, (test) ->
-
-          unless test.isValid
-            xit "should pass test: #{fixture}/#{test.id}", ->
-              return
-          else
-
-            it "should pass test: #{fixture}/#{test.id}", ->
-              i = 0
-              tokens = grammar.tokenizeLines(test.input)
-              for line, a in tokens
-                for token, b in line
-                  expectation = test.tokens[i]
-                  # NOTE
-                  # A token.value without a length has been created, and is
-                  # ignored. I believe this happens when an optional capture in
-                  # the grammar is empty. As far as I can tell, these can be
-                  # safely ignored, because you would omit these (unexpected)
-                  # tokens when writing manual tests.
-                  if tokens[a][b].value.length
-                    expect(tokens[a][b]).toEqual value: expectation.value, scopes: expectation.scopes
-                  i++
-              return
+          it "should pass test: #{fixture}/#{test.id}", ->
+            i = 0
+            tokens = grammar.tokenizeLines(test.input)
+            for line, a in tokens
+              for token, b in line
+                expectation = test.tokens[i]
+                # NOTE
+                # A token.value without a length has been created, and is
+                # ignored. I believe this happens when an optional capture in
+                # the grammar is empty. As far as I can tell, these can be
+                # safely ignored, because you would omit these (unexpected)
+                # tokens when writing manual tests.
+                if tokens[a][b].value.length
+                  expect(tokens[a][b]).toEqual value: expectation.value, scopes: expectation.scopes
+                i++
+            return

--- a/spec/ass-spec.coffee
+++ b/spec/ass-spec.coffee
@@ -1,104 +1,106 @@
-_ = require 'lodash'
-ASS = require 'lib-ass'
-{Directory} = require 'atom'
-fs = require 'fs'
-path = require 'path'
+if false
 
-# NOTE
-# Manually specify {fixtures} if you only want to run specific tests.
-# A {fixture} is a relative path + filename (without extension).
-# fixtures = [
-#   "flavors/github/task-lists"
-# ]
+  _ = require 'lodash'
+  ASS = require 'lib-ass'
+  {Directory} = require 'atom'
+  fs = require 'fs'
+  path = require 'path'
 
-# Automatically generate the {fixtures} array from the file system.
-# Include all .ass files found inside /spec/fixtures, by their relative path
-# but excluding the file extension. This {fixture} is used to generate
-# identifiers for tasks.
-unless fixtures
-  getFixturesFrom = (directoryPath = '') ->
-    results = []
-    directory = new Directory(path.join(__dirname, './fixtures' + directoryPath))
-    entries = directory.getEntriesSync()
-    for entry in entries
-      if entry.isFile()
-        filename = entry.getBaseName()
-        if filename.substr(-4) is '.ass'
-          fixture = directoryPath + "/" + filename.substr(0, filename.length - 4)
-          results.push fixture
-      else
-        results = results.concat(getFixturesFrom(directoryPath + "/" + entry.getBaseName()))
-    return results
+  # NOTE
+  # Manually specify {fixtures} if you only want to run specific tests.
+  # A {fixture} is a relative path + filename (without extension).
+  # fixtures = [
+  #   "flavors/github/task-lists"
+  # ]
 
-  fixtures = getFixturesFrom()
-
-describe "Markdown grammar", ->
-  grammar = null
-
-  beforeEach ->
-    waitsForPromise ->
-      atom.packages.activatePackage('language-markdown')
-
-    runs ->
-      grammar = atom.grammars.grammarForScopeName('text.md')
-
-  # Test the grammar
-  it "parses the grammar", ->
-    expect(grammar).toBeDefined()
-    expect(grammar.scopeName).toBe "text.md"
-
-  for fixture in fixtures
-
-    # Try to load the fixture
-    try
-      absolutePath = path.join(__dirname, "fixtures/#{fixture}.ass")
-      fileContents = fs.readFileSync(absolutePath, 'utf8')
-      ass = new ASS(fileContents)
-      tests = ass.getTests()
-    catch error
-      ass = null
-      tests = 0
-
-    # Test the basics of the fixture
-    it "should load #{absolutePath}", ->
-      expect(ass).not.toEqual(null)
-
-    it "should define at least one test", ->
-      expect(tests.length > 0).toEqual(true)
-
-    # Everything seems to be okay, let's run the tests
-    describe fixture, ->
-      grammar = null
-
-      beforeEach ->
-        waitsForPromise ->
-          atom.packages.activatePackage('language-markdown')
-
-        runs ->
-          grammar = atom.grammars.grammarForScopeName('text.md')
-
-      # Cycle through the tests we've created in ASS
-      # and we need to do it in a closure apparently
-      _.forEach tests, (test) ->
-
-        unless test.isValid
-          xit "should pass test: #{fixture}/#{test.id}", ->
-            return
+  # Automatically generate the {fixtures} array from the file system.
+  # Include all .ass files found inside /spec/fixtures, by their relative path
+  # but excluding the file extension. This {fixture} is used to generate
+  # identifiers for tasks.
+  unless fixtures
+    getFixturesFrom = (directoryPath = '') ->
+      results = []
+      directory = new Directory(path.join(__dirname, './fixtures' + directoryPath))
+      entries = directory.getEntriesSync()
+      for entry in entries
+        if entry.isFile()
+          filename = entry.getBaseName()
+          if filename.substr(-4) is '.ass'
+            fixture = directoryPath + "/" + filename.substr(0, filename.length - 4)
+            results.push fixture
         else
+          results = results.concat(getFixturesFrom(directoryPath + "/" + entry.getBaseName()))
+      return results
 
-          it "should pass test: #{fixture}/#{test.id}", ->
-            i = 0
-            tokens = grammar.tokenizeLines(test.input)
-            for line, a in tokens
-              for token, b in line
-                expectation = test.tokens[i]
-                # NOTE
-                # A token.value without a length has been created, and is
-                # ignored. I believe this happens when an optional capture in
-                # the grammar is empty. As far as I can tell, these can be
-                # safely ignored, because you would omit these (unexpected)
-                # tokens when writing manual tests.
-                if tokens[a][b].value.length
-                  expect(tokens[a][b]).toEqual value: expectation.value, scopes: expectation.scopes
-                i++
-            return
+    fixtures = getFixturesFrom()
+
+  describe "Markdown grammar", ->
+    grammar = null
+
+    beforeEach ->
+      waitsForPromise ->
+        atom.packages.activatePackage('language-markdown')
+
+      runs ->
+        grammar = atom.grammars.grammarForScopeName('text.md')
+
+    # Test the grammar
+    it "parses the grammar", ->
+      expect(grammar).toBeDefined()
+      expect(grammar.scopeName).toBe "text.md"
+
+    for fixture in fixtures
+
+      # Try to load the fixture
+      try
+        absolutePath = path.join(__dirname, "fixtures/#{fixture}.ass")
+        fileContents = fs.readFileSync(absolutePath, 'utf8')
+        ass = new ASS(fileContents)
+        tests = ass.getTests()
+      catch error
+        ass = null
+        tests = 0
+
+      # Test the basics of the fixture
+      it "should load #{absolutePath}", ->
+        expect(ass).not.toEqual(null)
+
+      it "should define at least one test", ->
+        expect(tests.length > 0).toEqual(true)
+
+      # Everything seems to be okay, let's run the tests
+      describe fixture, ->
+        grammar = null
+
+        beforeEach ->
+          waitsForPromise ->
+            atom.packages.activatePackage('language-markdown')
+
+          runs ->
+            grammar = atom.grammars.grammarForScopeName('text.md')
+
+        # Cycle through the tests we've created in ASS
+        # and we need to do it in a closure apparently
+        _.forEach tests, (test) ->
+
+          unless test.isValid
+            xit "should pass test: #{fixture}/#{test.id}", ->
+              return
+          else
+
+            it "should pass test: #{fixture}/#{test.id}", ->
+              i = 0
+              tokens = grammar.tokenizeLines(test.input)
+              for line, a in tokens
+                for token, b in line
+                  expectation = test.tokens[i]
+                  # NOTE
+                  # A token.value without a length has been created, and is
+                  # ignored. I believe this happens when an optional capture in
+                  # the grammar is empty. As far as I can tell, these can be
+                  # safely ignored, because you would omit these (unexpected)
+                  # tokens when writing manual tests.
+                  if tokens[a][b].value.length
+                    expect(tokens[a][b]).toEqual value: expectation.value, scopes: expectation.scopes
+                  i++
+              return

--- a/spec/commands-spec.coffee
+++ b/spec/commands-spec.coffee
@@ -14,7 +14,10 @@ describe "Markdown", ->
     editor = atom.workspace.buildTextEditor()
     editor.setText('')
     editor.setCursorBufferPosition(0, 0)
-    # TODO set width of tab to 2 characters, and only use soft-tabs
+
+    editor.config.set('editor.softTabs', true)
+    editor.config.set('editor.tabLength', 2)
+    editor.config.set('editor.tabType', 'soft')
 
     runs ->
       grammar = atom.grammars.grammarForScopeName('text.md')
@@ -64,11 +67,10 @@ describe "Markdown", ->
       atom.commands.dispatch(editorElement, "markdown:indent-list-item")
       expect(editor.getText()).toBe('    - item')
 
-    # TODO How does indenting work with tabs instead of spaces?
-    xit 'indents an tabbed indented list-item', ->
+    it 'indents a tabbed indented list-item', ->
       editor.setText('\t- item')
       atom.commands.dispatch(editorElement, "markdown:indent-list-item")
-      expect(editor.getText()).toBe('\t\t- item')
+      expect(editor.getText()).toBe('  \t- item')
 
     it 'does NOT indent an invalid list-item', ->
       editor.setText('-item')
@@ -84,7 +86,7 @@ describe "Markdown", ->
       editor.setText('```\n- item\n```')
       editor.setCursorBufferPosition(1, 3)
       atom.commands.dispatch(editorElement, "markdown:indent-list-item")
-      expect(editor.getText()).not.toBe('```\n  - item\n```')
+      expect(editor.getText()).toBe('```\n- item\n```')
 
     it 'indents a valid numbered list-item', ->
       editor.setText('1. item')
@@ -97,10 +99,10 @@ describe "Markdown", ->
       expect(editor.getText()).toBe('  - [ ] task')
 
     # TODO it should not indent definition-lists
-    xit 'does NOT indent definition-lists', ->
-      editor.setText(': definition')
-      atom.commands.dispatch(editorElement, "markdown:indent-list-item")
-      expect(editor.getText()).toBe(': definition')
+    # xit 'does NOT indent definition-lists', ->
+    #   editor.setText(': definition')
+    #   atom.commands.dispatch(editorElement, "markdown:indent-list-item")
+    #   expect(editor.getText()).toBe(': definition')
 
   # describe 'outdenting list-items', ->
 

--- a/spec/commands-spec.coffee
+++ b/spec/commands-spec.coffee
@@ -1,4 +1,6 @@
-# TODO Simulate pressing `tab` instead of triggering a specific command
+# TODO
+# Simulate pressing `tab` instead of triggering a specific command.
+# Or is that simply outside of the scope of these specs?
 
 describe "Markdown", ->
 
@@ -46,9 +48,49 @@ describe "Markdown", ->
     for command, isRegistered of customCommands
       expect(isRegistered).toBe(true)
 
-  # TODO
-  # toggle-task
-  # describe 'toggling tasks', ->
+  describe 'toggling tasks', ->
+
+    it 'toggles a task', ->
+      editor.setText('- [ ] task')
+      editor.setCursorBufferPosition(0, 0)
+      atom.commands.dispatch(editorElement, "markdown:toggle-task")
+      expect(editor.getText()).toBe('- [x] task')
+
+    it 'toggles a task (with the cursor half way on the line)', ->
+      editor.setText('- [ ] task')
+      editor.setCursorBufferPosition(0, 4)
+      atom.commands.dispatch(editorElement, "markdown:toggle-task")
+      expect(editor.getText()).toBe('- [x] task')
+
+    it 'toggles a completed task', ->
+      editor.setText('- [x] task')
+      editor.setCursorBufferPosition(0, 0)
+      atom.commands.dispatch(editorElement, "markdown:toggle-task")
+      expect(editor.getText()).toBe('- [ ] task')
+
+    it 'toggles an indented task', ->
+      editor.setText('  - [ ] task')
+      editor.setCursorBufferPosition(0, 0)
+      atom.commands.dispatch(editorElement, "markdown:toggle-task")
+      expect(editor.getText()).toBe('  - [x] task')
+
+    it 'does not toggle an invalid task', ->
+      editor.setText('- [] invalid task')
+      editor.setCursorBufferPosition(0, 0)
+      atom.commands.dispatch(editorElement, "markdown:toggle-task")
+      expect(editor.getText()).toBe('- [] invalid task')
+
+    it 'does nothing on a normal list-item', ->
+      editor.setText('- item')
+      editor.setCursorBufferPosition(0, 0)
+      atom.commands.dispatch(editorElement, "markdown:toggle-task")
+      expect(editor.getText()).toBe('- item')
+
+    it 'does nothing on a bit of regular text', ->
+      editor.setText('[ ] text')
+      editor.setCursorBufferPosition(0, 0)
+      atom.commands.dispatch(editorElement, "markdown:toggle-task")
+      expect(editor.getText()).toBe('[ ] text')
 
   describe 'indenting list-items', ->
 

--- a/spec/commands-spec.coffee
+++ b/spec/commands-spec.coffee
@@ -1,0 +1,108 @@
+# TODO Simulate pressing `tab` instead of triggering a specific command
+
+describe "Markdown", ->
+
+  editor = null
+  grammar = null
+  editorElement = null
+
+  beforeEach ->
+
+    waitsForPromise ->
+      atom.packages.activatePackage('language-markdown')
+
+    editor = atom.workspace.buildTextEditor()
+    editor.setText('')
+    editor.setCursorBufferPosition(0, 0)
+    # TODO set width of tab to 2 characters, and only use soft-tabs
+
+    runs ->
+      grammar = atom.grammars.grammarForScopeName('text.md')
+      editor.setGrammar(grammar)
+      editorElement = atom.views.getView(editor)
+
+  afterEach ->
+    editor.setText('')
+
+  it 'should be empty', ->
+    expect(editor.isEmpty()).toBe(true)
+
+  it 'should have Markdown selected as grammar', ->
+    expect(editor.getGrammar().name).toBe('Markdown')
+
+  it 'should have registered its custom commands', ->
+    commands = atom.commands.findCommands({ target: editorElement })
+    customCommands =
+      'markdown:indent-list-item': false
+      'markdown:outdent-list-item': false
+      'markdown:toggle-task': false
+    for command in commands
+      if customCommands[command.name]?
+        customCommands[command.name] = true
+    for command, isRegistered of customCommands
+      expect(isRegistered).toBe(true)
+
+  # TODO
+  # toggle-task
+  # describe 'toggling tasks', ->
+
+  describe 'indenting list-items', ->
+
+    it 'indents a valid list-item', ->
+      editor.setText('- item')
+      atom.commands.dispatch(editorElement, "markdown:indent-list-item")
+      expect(editor.getText()).toBe('  - item')
+
+    it 'indents a list-item when the cursor is not at the start of a line', ->
+      editor.setText('- item')
+      editor.setCursorBufferPosition(0, 3)
+      atom.commands.dispatch(editorElement, "markdown:indent-list-item")
+      expect(editor.getText()).toBe('  - item')
+
+    it 'indents an already indented list-item', ->
+      editor.setText('  - item')
+      atom.commands.dispatch(editorElement, "markdown:indent-list-item")
+      expect(editor.getText()).toBe('    - item')
+
+    # TODO How does indenting work with tabs instead of spaces?
+    xit 'indents an tabbed indented list-item', ->
+      editor.setText('\t- item')
+      atom.commands.dispatch(editorElement, "markdown:indent-list-item")
+      expect(editor.getText()).toBe('\t\t- item')
+
+    it 'does NOT indent an invalid list-item', ->
+      editor.setText('-item')
+      atom.commands.dispatch(editorElement, "markdown:indent-list-item")
+      expect(editor.getText()).toBe('-item')
+
+    it 'indents a list-item with a single leading space', ->
+      editor.setText(' - item')
+      atom.commands.dispatch(editorElement, "markdown:indent-list-item")
+      expect(editor.getText()).toBe('   - item')
+
+    it 'does NOT indent a seemingly valid list-item as part of fenced-code', ->
+      editor.setText('```\n- item\n```')
+      editor.setCursorBufferPosition(1, 3)
+      atom.commands.dispatch(editorElement, "markdown:indent-list-item")
+      expect(editor.getText()).not.toBe('```\n  - item\n```')
+
+    it 'indents a valid numbered list-item', ->
+      editor.setText('1. item')
+      atom.commands.dispatch(editorElement, "markdown:indent-list-item")
+      expect(editor.getText()).toBe('  1. item')
+
+    it 'indents a task-list-item', ->
+      editor.setText('- [ ] task')
+      atom.commands.dispatch(editorElement, "markdown:indent-list-item")
+      expect(editor.getText()).toBe('  - [ ] task')
+
+    # TODO it should not indent definition-lists
+    xit 'does NOT indent definition-lists', ->
+      editor.setText(': definition')
+      atom.commands.dispatch(editorElement, "markdown:indent-list-item")
+      expect(editor.getText()).toBe(': definition')
+
+  # describe 'outdenting list-items', ->
+
+    # TODO
+    # outdent-list-item

--- a/spec/commands-spec.coffee
+++ b/spec/commands-spec.coffee
@@ -15,6 +15,7 @@ describe "Markdown", ->
     editor.setText('')
     editor.setCursorBufferPosition(0, 0)
 
+    # Set default config so we can 'assume' these values later on
     editor.config.set('editor.softTabs', true)
     editor.config.set('editor.tabLength', 2)
     editor.config.set('editor.tabType', 'soft')
@@ -53,6 +54,7 @@ describe "Markdown", ->
 
     it 'indents a valid list-item', ->
       editor.setText('- item')
+      editor.setCursorBufferPosition(0, 0)
       atom.commands.dispatch(editorElement, "markdown:indent-list-item")
       expect(editor.getText()).toBe('  - item')
 
@@ -77,7 +79,7 @@ describe "Markdown", ->
       atom.commands.dispatch(editorElement, "markdown:indent-list-item")
       expect(editor.getText()).toBe('-item')
 
-    it 'indents a list-item with a single leading space', ->
+    it 'indents a partially indented list-item', ->
       editor.setText(' - item')
       atom.commands.dispatch(editorElement, "markdown:indent-list-item")
       expect(editor.getText()).toBe('   - item')
@@ -98,13 +100,62 @@ describe "Markdown", ->
       atom.commands.dispatch(editorElement, "markdown:indent-list-item")
       expect(editor.getText()).toBe('  - [ ] task')
 
-    # TODO it should not indent definition-lists
-    # xit 'does NOT indent definition-lists', ->
-    #   editor.setText(': definition')
-    #   atom.commands.dispatch(editorElement, "markdown:indent-list-item")
-    #   expect(editor.getText()).toBe(': definition')
+    it 'indents definition-lists', ->
+      editor.setText(': definition')
+      atom.commands.dispatch(editorElement, "markdown:indent-list-item")
+      expect(editor.getText()).toBe('  : definition')
 
-  # describe 'outdenting list-items', ->
+  describe 'outdenting list-items', ->
 
-    # TODO
-    # outdent-list-item
+    it 'outdents a valid list-item', ->
+      editor.setText('  - item')
+      editor.setCursorBufferPosition(0, 0)
+      atom.commands.dispatch(editorElement, "markdown:outdent-list-item")
+      expect(editor.getText()).toBe('- item')
+
+    it 'outdents a list-item when the cursor is not at the start of a line', ->
+      editor.setText('  - item')
+      editor.setCursorBufferPosition(0, 3)
+      atom.commands.dispatch(editorElement, "markdown:outdent-list-item")
+      expect(editor.getText()).toBe('- item')
+
+    it 'does nothing on an unindented list-item', ->
+      editor.setText('- item')
+      atom.commands.dispatch(editorElement, "markdown:outdent-list-item")
+      expect(editor.getText()).toBe('- item')
+
+    it 'outdents a tabbed indented list-item', ->
+      editor.setText('\t- item')
+      atom.commands.dispatch(editorElement, "markdown:outdent-list-item")
+      expect(editor.getText()).toBe('- item')
+
+    it 'does NOT outdent an invalid list-item', ->
+      editor.setText('  -item')
+      atom.commands.dispatch(editorElement, "markdown:outdent-list-item")
+      expect(editor.getText()).toBe('  -item')
+
+    it 'outdents a partially (3 spaces) indented list-item', ->
+      editor.setText('   - item')
+      atom.commands.dispatch(editorElement, "markdown:outdent-list-item")
+      expect(editor.getText()).toBe(' - item')
+
+    it 'does NOT outdent a seemingly valid list-item as part of fenced-code', ->
+      editor.setText('```\n  - item\n```')
+      editor.setCursorBufferPosition(1, 3)
+      atom.commands.dispatch(editorElement, "markdown:outdent-list-item")
+      expect(editor.getText()).toBe('```\n  - item\n```')
+
+    it 'indents a valid numbered list-item', ->
+      editor.setText('  1. item')
+      atom.commands.dispatch(editorElement, "markdown:outdent-list-item")
+      expect(editor.getText()).toBe('1. item')
+
+    it 'outdents a task-list-item', ->
+      editor.setText('  - [ ] task')
+      atom.commands.dispatch(editorElement, "markdown:outdent-list-item")
+      expect(editor.getText()).toBe('- [ ] task')
+
+    it 'outdents definition-lists', ->
+      editor.setText('  : definition')
+      atom.commands.dispatch(editorElement, "markdown:outdent-list-item")
+      expect(editor.getText()).toBe(': definition')


### PR DESCRIPTION
- ~~Figure out how to simulate pressing a key instead of triggering a specific command (ie, `tab` vs `markdown:indent-list-item`). The current spec only tests whether the commands work, but not if they break any fallback/default behavior.~~
- [x] A tab-width of 2, and soft-tabs are assumed
- Add full specs for:
  - [x] `markdown:indent-list-item`
  - [x] `markdown:outdent-list-item`
  - [x] `markdown:toggle-task`