### PR TITLE
Improve compatibility with default/other syntax themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ If you experience any issue above a reasonable/tolerable level of annoyancy, don
   - Toggle tasks with <kbd>cmd+shift+x</kbd> or <kbd>ctrl+shift+x</kbd>
   - Remove empty list-items when pressing <kbd>enter</kbd>
 
+## Syntax theme support
+
+TODO List of (default) themes that are supported
+TODO How to add syntax highlighting to your own theme
+
 ## Installation instructions
 
 1. Install `language-markdown` via

--- a/grammars/language-markdown.json
+++ b/grammars/language-markdown.json
@@ -415,15 +415,15 @@
     "hr": {
       "patterns": [
         {
-          "name": "hr.markup.md",
+          "name": "hr.constant.markup.md",
           "match": "^[ ]{0,3}[-]{1,} *[-]{1,} *[-]{1,}[ -]*$"
         },
         {
-          "name": "hr.markup.md",
+          "name": "hr.constant.markup.md",
           "match": "^[ ]{0,3}[*]{1,} *[*]{1,} *[*]{1,}[ *]*$"
         },
         {
-          "name": "hr.markup.md",
+          "name": "hr.constant.markup.md",
           "match": "^[ ]{0,3}[_]{1,} *[_]{1,} *[_]{1,}[ _]*$"
         }
       ]
@@ -689,13 +689,13 @@
           "begin": "\\A---$",
           "beginCaptures": {
             "0": {
-              "name": "hr.constant.md"
+              "name": "hr.constant.markup.md"
             }
           },
           "end": "^(---|\\.\\.\\.)$",
           "endCaptures": {
             "1": {
-              "name": "hr.constant.md"
+              "name": "hr.constant.markup.md"
             }
           },
           "name": "front-matter.yaml.source.md",
@@ -709,13 +709,13 @@
           "begin": "\\A\\+\\+\\+$",
           "beginCaptures": {
             "0": {
-              "name": "hr.constant.md"
+              "name": "hr.constant.markup.md"
             }
           },
           "end": "^\\+\\+\\+$",
           "endCaptures": {
             "0": {
-              "name": "hr.constant.md"
+              "name": "hr.constant.markup.md"
             }
           },
           "name": "front-matter.toml.source.md",
@@ -944,7 +944,7 @@
     "markdown-extra": {
       "patterns": [
         {
-          "name": "definition.list.markup.md",
+          "name": "definition.list.markup.entity.md",
           "match": "^(?:\\s*)(:)( +)(.*)$",
           "captures": {
             "1": {
@@ -953,7 +953,7 @@
           }
         },
         {
-          "name": "abbreviation.reference.link.markup.md",
+          "name": "abbreviation.reference.link.markup.entity.md",
           "match": "^((?:\\*\\[)(?:[^\\]]+)(?:\\]))(:) (.*)$",
           "captures": {
             "1": {
@@ -1348,7 +1348,7 @@
               "name": "punctuation.md"
             },
             "2": {
-              "name": "link.markup.md"
+              "name": "link.markup.entity.md"
             },
             "3": {
               "patterns": [
@@ -1466,7 +1466,7 @@
     "links": {
       "patterns": [
         {
-          "name": "reference.footnote.link.markup.md",
+          "name": "reference.footnote.link.markup.entity.md",
           "match": "((?:\\[\\^)(?:[^\\[\\]]+)(?:\\]))(?!:)",
           "captures": {
             "1": {
@@ -1479,7 +1479,7 @@
           }
         },
         {
-          "name": "definition.footnote.link.markup.md",
+          "name": "definition.footnote.link.markup.entity.md",
           "match": "((?:\\[\\^)(?:[^\\[\\]]+)(?:\\]))(:)",
           "captures": {
             "1": {

--- a/grammars/language-markdown.json
+++ b/grammars/language-markdown.json
@@ -158,7 +158,7 @@
       "patterns": [
         {
           "match": "^(?:[ ]{0,3})((?:#{1,6})\\s*(?:#*)\\s*)$",
-          "name": "empty.heading.markup.md",
+          "name": "empty.heading.support.markup.md",
           "captures": {
             "1": {
               "patterns": [
@@ -240,7 +240,7 @@
         },
         {
           "match": "^((?: {0,3})(?:#{1,6})(?: +)(?:.+))$",
-          "name": "heading.markup.md",
+          "name": "heading.support.markup.md",
           "captures": {
             "1": {
               "patterns": [
@@ -415,15 +415,15 @@
     "hr": {
       "patterns": [
         {
-          "name": "hr.md",
+          "name": "hr.markup.md",
           "match": "^[ ]{0,3}[-]{1,} *[-]{1,} *[-]{1,}[ -]*$"
         },
         {
-          "name": "hr.md",
+          "name": "hr.markup.md",
           "match": "^[ ]{0,3}[*]{1,} *[*]{1,} *[*]{1,}[ *]*$"
         },
         {
-          "name": "hr.md",
+          "name": "hr.markup.md",
           "match": "^[ ]{0,3}[_]{1,} *[_]{1,} *[_]{1,}[ _]*$"
         }
       ]
@@ -689,13 +689,13 @@
           "begin": "\\A---$",
           "beginCaptures": {
             "0": {
-              "name": "hr.md"
+              "name": "hr.constant.md"
             }
           },
           "end": "^(---|\\.\\.\\.)$",
           "endCaptures": {
             "1": {
-              "name": "hr.md"
+              "name": "hr.constant.md"
             }
           },
           "name": "front-matter.yaml.source.md",
@@ -709,13 +709,13 @@
           "begin": "\\A\\+\\+\\+$",
           "beginCaptures": {
             "0": {
-              "name": "hr.md"
+              "name": "hr.constant.md"
             }
           },
           "end": "^\\+\\+\\+$",
           "endCaptures": {
             "0": {
-              "name": "hr.md"
+              "name": "hr.constant.md"
             }
           },
           "name": "front-matter.toml.source.md",
@@ -746,13 +746,13 @@
                   "match": "(:?)(-+)(:?)",
                   "captures": {
                     "1": {
-                      "name": "alignment.punctuation.md"
+                      "name": "alignment.punctuation.meta.md"
                     },
                     "2": {
                       "name": "punctuation.md"
                     },
                     "3": {
-                      "name": "alignment.punctuation.md"
+                      "name": "alignment.punctuation.meta.md"
                     }
                   }
                 },
@@ -1438,7 +1438,7 @@
     "link-title": {
       "patterns": [
         {
-          "name": "title.link.md",
+          "name": "title.link.meta.md",
           "match": "^(['|\"])(.*)(\\1)$",
           "captures": {
             "1": {
@@ -1450,7 +1450,7 @@
           }
         },
         {
-          "name": "title.link.md",
+          "name": "title.link.meta.md",
           "match": "^(\\()(.*)(\\))$",
           "captures": {
             "1": {
@@ -1495,7 +1495,7 @@
           }
         },
         {
-          "name": "link.markup.md",
+          "name": "link.markup.entity.md",
           "match": "(?x) ( (?:\\[) (?: (?: (?:!\\[) (?:[^\\[\\]]*) (?:\\]) ) (?:\\() (?:[^ [:cntrl:]]+)? (?: (?:\\s+) (?: (?:[\"'\\(]) .*? (?:[\"'\\)]) ) (?:\\s*) )? (?:\\)) (?:\\{[[:ascii:]]*\\})? ) (?:\\]) ) (\\() ([^ [:cntrl:]]+)? (?: (?:\\s+) ( (?:[\"'\\(]) .*? (?:[\"'\\)]) ) (?:\\s*) )? (\\)) (\\{[[:ascii:]]*\\})?",
           "captures": {
             "1": {
@@ -1535,7 +1535,7 @@
           }
         },
         {
-          "name": "link.markup.md",
+          "name": "link.markup.entity.md",
           "match": "(?x) ( (?:!?\\[) (?:[^\\[\\]]*) (?:\\]) ) (\\() ([^ [:cntrl:]]+)? (?: (?:\\s+) ( (?:[\"'\\(]) .*? (?:[\"'\\)]) ) (?:\\s*) )? (\\)) (\\{[[:ascii:]]*\\})?",
           "captures": {
             "1": {
@@ -1575,7 +1575,7 @@
           }
         },
         {
-          "name": "link.markup.md",
+          "name": "link.markup.entity.md",
           "match": "(?x) ( (?:!?\\[) (?:[^\\[\\]]*) (?:\\]) ) (\\() (<[^[:cntrl:]]*>) (?: (?:\\s+) ( (?:[\"'\\(]) .*? (?:[\"'\\)]) ) (?:\\s*) )? (\\)) (\\{[[:ascii:]]*\\})?",
           "captures": {
             "1": {
@@ -1615,7 +1615,7 @@
           }
         },
         {
-          "name": "link.markup.md",
+          "name": "link.markup.entity.md",
           "match": "(?x) ( (?:\\[) (?: (?: (?:!\\[) (?:[^\\[\\]]*) (?:\\]) ) (?:\\() (?:[^ [:cntrl:]]+)? (?: (?:\\s+) (?: (?:[\"'\\(]) .*? (?:[\"'\\)]) ) (?:\\s*) )? (?:\\)) (?:\\{[[:ascii:]]*\\})? ) (?:\\]) ) ( (?:\\[) (?:[^\\[\\]]*) (?:\\]) ) (\\{[[:ascii:]]*\\})?",
           "captures": {
             "1": {
@@ -1642,7 +1642,7 @@
           }
         },
         {
-          "name": "link.markup.md",
+          "name": "link.markup.entity.md",
           "match": "(?x) ( (?:!?\\[) (?:[^\\[\\]]*) (?:\\]) ) ( (?:\\[) (?:[^\\[\\]]*) (?:\\]) ) (\\{[[:ascii:]]*\\})?",
           "captures": {
             "1": {
@@ -1669,7 +1669,7 @@
           }
         },
         {
-          "name": "link.markup.md",
+          "name": "link.markup.entity.md",
           "match": "(?x) ( (?:!\\[) (?:[^\\[\\]]*) (?:\\]) ) (\\{[[:ascii:]]*\\})?",
           "captures": {
             "1": {
@@ -1689,7 +1689,7 @@
           }
         },
         {
-          "name": "reference.link.markup.md",
+          "name": "reference.link.markup.entity.md",
           "match": "(?x) ((?:\\[)(?:[^\\[\\]]*)(?:\\])) (:) (?:\\s) ([^ [:cntrl:]]+) (?:(?:\\s)((?:\")(?:.*?)(?:\")))? (?:(?:\\s)(\\{[[:ascii:]]*\\}))?",
           "captures": {
             "1": {
@@ -1745,7 +1745,7 @@
           }
         },
         {
-          "name": "auto.link.markup.md",
+          "name": "auto.link.markup.entity.md",
           "match": "(?i:(<)((coap|doi|javascript|aaa|aaas|about|acap|cap|cid|crid|data|dav|dict|dns|file|ftp|geo|go|gopher|h323|http|https|iax|icap|im|imap|info|ipp|iris|iris.beep|iris.xpc|iris.xpcs|iris.lwz|ldap|mailto|mid|msrp|msrps|mtqp|mupdate|news|nfs|ni|nih|nntp|opaquelocktoken|pop|pres|rtsp|service|session|shttp|sieve|sip|sips|sms|snmp|soap.beep|soap.beeps|tag|tel|telnet|tftp|thismessage|tn3270|tip|tv|urn|vemmi|ws|wss|xcon|xcon-userid|xmlrpc.beep|xmlrpc.beeps|xmpp|z39.50r|z39.50s|adiumxtra|afp|afs|aim|apt|attachment|aw|beshare|bitcoin|bolo|callto|chrome|chrome-extension|com-eventbrite-attendee|content|cvs|dlna-playsingle|dlna-playcontainer|dtn|dvb|ed2k|facetime|feed|finger|fish|gg|git|gizmoproject|gtalk|hcp|icon|ipn|irc|irc6|ircs|itms|jar|jms|keyparc|lastfm|ldaps|magnet|maps|market|message|mms|ms-help|msnim|mumble|mvn|notes|oid|palm|paparazzi|platform|proxy|psyc|query|res|resource|rmi|rsync|rtmp|secondlife|sftp|sgn|skype|smb|soldat|spotify|ssh|steam|svn|teamspeak|things|udp|unreal|ut2004|ventrilo|view-source|webcal|wtai|wyciwyg|xfire|xri|ymsgr):(?:[^ [:cntrl:]<>]+))(>))",
           "captures": {
             "1": {
@@ -1763,7 +1763,7 @@
           }
         },
         {
-          "name": "email.auto.link.markup.md",
+          "name": "email.auto.link.markup.entity.md",
           "match": "(<)(([a-zA-Z0-9\\.!#$%&'\\*\\+/=?^_`{\\|}~-]+)(@)([a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*))(>)",
           "captures": {
             "1": {

--- a/grammars/language-markdown.json
+++ b/grammars/language-markdown.json
@@ -1,6 +1,6 @@
 {
   "name": "Markdown",
-  "scopeName": "text.md",
+  "scopeName": "source.text.md",
   "fileTypes": [
     "markdown",
     "md",

--- a/grammars/repositories/blocks/headings.cson
+++ b/grammars/repositories/blocks/headings.cson
@@ -3,7 +3,7 @@ patterns: [
   {
     # Empty headings
     match: '^(?:[ ]{0,3})((?:#{1,6})\\s*(?:#*)\\s*)$'
-    name: 'empty.heading.markup.md'
+    name: 'empty.heading.support.markup.md'
     captures:
       1:
         patterns: [
@@ -63,7 +63,7 @@ patterns: [
     # match for a heading? It seems more logical to test against one match, than
     # to go through all six of them every iteration.
     match: '^((?: {0,3})(?:#{1,6})(?: +)(?:.+))$'
-    name: 'heading.markup.md'
+    name: 'heading.support.markup.md'
     captures:
       1:
         patterns: [

--- a/grammars/repositories/blocks/hr.cson
+++ b/grammars/repositories/blocks/hr.cson
@@ -1,15 +1,15 @@
 key: 'hr'
 patterns: [
   {
-    name: 'hr.md'
+    name: 'hr.markup.md'
     match: '^[ ]{0,3}[-]{1,} *[-]{1,} *[-]{1,}[ -]*$'
   }
   {
-    name: 'hr.md'
+    name: 'hr.markup.md'
     match: '^[ ]{0,3}[*]{1,} *[*]{1,} *[*]{1,}[ \*]*$'
   }
   {
-    name: 'hr.md'
+    name: 'hr.markup.md'
     match: '^[ ]{0,3}[_]{1,} *[_]{1,} *[_]{1,}[ _]*$'
   }
 ]

--- a/grammars/repositories/blocks/hr.cson
+++ b/grammars/repositories/blocks/hr.cson
@@ -1,15 +1,15 @@
 key: 'hr'
 patterns: [
   {
-    name: 'hr.markup.md'
+    name: 'hr.constant.markup.md'
     match: '^[ ]{0,3}[-]{1,} *[-]{1,} *[-]{1,}[ -]*$'
   }
   {
-    name: 'hr.markup.md'
+    name: 'hr.constant.markup.md'
     match: '^[ ]{0,3}[*]{1,} *[*]{1,} *[*]{1,}[ \*]*$'
   }
   {
-    name: 'hr.markup.md'
+    name: 'hr.constant.markup.md'
     match: '^[ ]{0,3}[_]{1,} *[_]{1,} *[_]{1,}[ _]*$'
   }
 ]

--- a/grammars/repositories/flavors/front-matter.cson
+++ b/grammars/repositories/flavors/front-matter.cson
@@ -3,20 +3,20 @@ patterns: [
   {
     begin: '\\A---$'
     beginCaptures:
-      0: name: 'hr.md'
+      0: name: 'hr.constant.md'
     end: '^(---|\\.\\.\\.)$'
     endCaptures:
-      1: name: 'hr.md'
+      1: name: 'hr.constant.md'
     name: 'front-matter.yaml.source.md'
     patterns: [{ include: 'source.yaml' }]
   }
   {
     begin: '\\A\\+\\+\\+$'
     beginCaptures:
-      0: name: 'hr.md'
+      0: name: 'hr.constant.md'
     end: '^\\+\\+\\+$'
     endCaptures:
-      0: name: 'hr.md'
+      0: name: 'hr.constant.md'
     name: 'front-matter.toml.source.md'
     patterns: [{ include: 'source.toml' }]
   }

--- a/grammars/repositories/flavors/front-matter.cson
+++ b/grammars/repositories/flavors/front-matter.cson
@@ -3,20 +3,20 @@ patterns: [
   {
     begin: '\\A---$'
     beginCaptures:
-      0: name: 'hr.constant.md'
+      0: name: 'hr.constant.markup.md'
     end: '^(---|\\.\\.\\.)$'
     endCaptures:
-      1: name: 'hr.constant.md'
+      1: name: 'hr.constant.markup.md'
     name: 'front-matter.yaml.source.md'
     patterns: [{ include: 'source.yaml' }]
   }
   {
     begin: '\\A\\+\\+\\+$'
     beginCaptures:
-      0: name: 'hr.constant.md'
+      0: name: 'hr.constant.markup.md'
     end: '^\\+\\+\\+$'
     endCaptures:
-      0: name: 'hr.constant.md'
+      0: name: 'hr.constant.markup.md'
     name: 'front-matter.toml.source.md'
     patterns: [{ include: 'source.toml' }]
   }

--- a/grammars/repositories/flavors/github-blocks.cson
+++ b/grammars/repositories/flavors/github-blocks.cson
@@ -4,7 +4,6 @@ patterns: [
   # Tables
   {
     name: 'table.storage.md'
-    # match: '^(\\|)(?=[ :])(.+)((?<=[ :])\\|?)\\s*$'
     match: '^(\\|)(?=[ :])(.+)$'
     captures:
       1: name: 'punctuation.md'
@@ -17,9 +16,9 @@ patterns: [
           {
             match: '(:?)(-+)(:?)'
             captures:
-              1: name: 'alignment.punctuation.md'
+              1: name: 'alignment.punctuation.meta.md'
               2: name: 'punctuation.md'
-              3: name: 'alignment.punctuation.md'
+              3: name: 'alignment.punctuation.meta.md'
           }
           {
             include: '#inlines-in-blocks'

--- a/grammars/repositories/flavors/github-inlines.cson
+++ b/grammars/repositories/flavors/github-inlines.cson
@@ -4,8 +4,6 @@ patterns: [
   # NOTE
   # From github.com/join: "Username may only contain alphanumeric characters or single hyphens, and cannot begin or end with a hyphen". The / is added to support @atom/feedback for instance.
   {
-    # match: '(?<=^|\\s|"|\'|\\(|\\[)((@)(\\w[-\\w:]*))(?=[\\s"\'.,;\\)\\]])'
-    # match: '(?<=^|\\s|"|\'|\\(|\\[)((@)(\\w[-\\w:/]*))(?=[\\s"\'.,;\\)\\]])'
     match: '(?<=^|\\s|"|\'|\\(|\\[)((@)([a-zA-Z0-9][a-zA-Z0-9\\-/]*[a-zA-Z0-9]))(?=[\\s"\'\\.,;:\\)\\]])'
     captures:
       1: name: 'reference.gfm.variable.md'
@@ -111,8 +109,6 @@ patterns: [
   }
 
   {
-    # begin: '(?<=^|[^\\w\\d~])~~(?!$|~|\\s)'
-    # end: '(?<!^|\\s)~~*~(?=$|[^\\w|\\d])'
     match: '(?<=^|[^\\w\\d~])(~~)(?!~)(.+?)(~~(?=$|[^\\w\\d~]))'
     name: 'strike.markup.md'
     captures:

--- a/grammars/repositories/flavors/markdown-extra.cson
+++ b/grammars/repositories/flavors/markdown-extra.cson
@@ -11,7 +11,7 @@ patterns: [
   # ---------------------
   # : letters and stuff
   {
-    name: 'definition.list.markup.md'
+    name: 'definition.list.markup.entity.md'
     match: '^(?:\\s*)(:)( +)(.*)$'
     captures:
       1: { name: 'punctuation.md' }
@@ -22,7 +22,7 @@ patterns: [
   # *[HTML]: Hyper Text Markup Language
   # *[W3C]:  World Wide Web Consortium
   {
-    name: 'abbreviation.reference.link.markup.md'
+    name: 'abbreviation.reference.link.markup.entity.md'
     match: '^((?:\\*\\[)(?:[^\\]]+)(?:\\]))(:) (.*)$'
     captures:
       1: patterns: [{ include: '#link-label' }]

--- a/grammars/repositories/inlines/code.cson
+++ b/grammars/repositories/inlines/code.cson
@@ -1,9 +1,6 @@
 key: 'code'
 patterns: [
   {
-    # begin: '(`+)(?!$)'
-    # end: '(?<!`)(\\1)(?!`)'
-    # match: '(?<!`)(`+)[^`]+(\\1)(?!`)'
     match: '(?<!`)(`{1,2})(?!`).+?(?<!`)(\\1)(?!`)'
     name: 'code.raw.markup.md'
     captures:

--- a/grammars/repositories/inlines/link-text.cson
+++ b/grammars/repositories/inlines/link-text.cson
@@ -28,7 +28,7 @@ patterns: [
     '
     captures:
       1: name: 'punctuation.md'
-      2: name: 'link.markup.md'
+      2: name: 'link.markup.entity.md'
       3: patterns: [{ include: '#link-text' }]
       4: name: 'punctuation.md'
       5: patterns: [{ include: '#link-destination' }]

--- a/grammars/repositories/inlines/link-title.cson
+++ b/grammars/repositories/inlines/link-title.cson
@@ -1,14 +1,14 @@
 key: 'link-title'
 patterns: [
   {
-    name: 'title.link.md'
+    name: 'title.link.meta.md'
     match: '^([\'|"])(.*)(\\1)$'
     captures:
       1: name: 'punctuation.md'
       3: name: 'punctuation.md'
   }
   {
-    name: 'title.link.md'
+    name: 'title.link.meta.md'
     match: '^(\\()(.*)(\\))$'
     captures:
       1: name: 'punctuation.md'

--- a/grammars/repositories/inlines/links.cson
+++ b/grammars/repositories/inlines/links.cson
@@ -23,7 +23,7 @@ patterns: [
   # [![image-alt](/image-url "image-title")](/link "link-title")
   # [![image-alt](/image-url "image-title"){special-attributes}](/link "link-title"){special-attributes}
   {
-    name: 'link.markup.md'
+    name: 'link.markup.entity.md'
     match: '(?x)
       (
         (?:\\[)
@@ -79,7 +79,7 @@ patterns: [
   # ![link](/uri)
   # ![link](/uri "title")
   {
-    name: 'link.markup.md'
+    name: 'link.markup.entity.md'
     match: '(?x)
       (
         (?:!?\\[)
@@ -113,7 +113,7 @@ patterns: [
   # [link](<> "title")
   # ![link](<> "title")
   {
-    name: 'link.markup.md'
+    name: 'link.markup.entity.md'
     match: '(?x)
       (
         (?:!?\\[)
@@ -146,7 +146,7 @@ patterns: [
   # [![image-alt](/image-url "image-title")][ref]
   # [![image-alt](/image-url "image-title"){special-attributes}][ref]{special-attributes}
   {
-    name: 'link.markup.md'
+    name: 'link.markup.entity.md'
     match: '(?x)
       (
         (?:\\[)
@@ -188,7 +188,7 @@ patterns: [
   # [foo][bar]
   # ![foo][bar]
   {
-    name: 'link.markup.md'
+    name: 'link.markup.entity.md'
     match: '(?x)
       (
         (?:!?\\[)
@@ -210,7 +210,7 @@ patterns: [
 
   # ![image]
   {
-    name: 'link.markup.md'
+    name: 'link.markup.entity.md'
     match: '(?x)
       (
         (?:!\\[)
@@ -227,7 +227,7 @@ patterns: [
   # [ref]: /uri
   # [ref]: /uri "title"
   {
-    name: 'reference.link.markup.md'
+    name: 'reference.link.markup.entity.md'
     match: '(?x)
       ((?:\\[)(?:[^\\[\\]]*)(?:\\]))
       (:)
@@ -262,7 +262,7 @@ patterns: [
 
   # auto-link: absolute uri
   {
-    name: 'auto.link.markup.md'
+    name: 'auto.link.markup.entity.md'
     match: '(?i:(<)((coap|doi|javascript|aaa|aaas|about|acap|cap|cid|crid|data|dav|dict|dns|file|ftp|geo|go|gopher|h323|http|https|iax|icap|im|imap|info|ipp|iris|iris.beep|iris.xpc|iris.xpcs|iris.lwz|ldap|mailto|mid|msrp|msrps|mtqp|mupdate|news|nfs|ni|nih|nntp|opaquelocktoken|pop|pres|rtsp|service|session|shttp|sieve|sip|sips|sms|snmp|soap.beep|soap.beeps|tag|tel|telnet|tftp|thismessage|tn3270|tip|tv|urn|vemmi|ws|wss|xcon|xcon-userid|xmlrpc.beep|xmlrpc.beeps|xmpp|z39.50r|z39.50s|adiumxtra|afp|afs|aim|apt|attachment|aw|beshare|bitcoin|bolo|callto|chrome|chrome-extension|com-eventbrite-attendee|content|cvs|dlna-playsingle|dlna-playcontainer|dtn|dvb|ed2k|facetime|feed|finger|fish|gg|git|gizmoproject|gtalk|hcp|icon|ipn|irc|irc6|ircs|itms|jar|jms|keyparc|lastfm|ldaps|magnet|maps|market|message|mms|ms-help|msnim|mumble|mvn|notes|oid|palm|paparazzi|platform|proxy|psyc|query|res|resource|rmi|rsync|rtmp|secondlife|sftp|sgn|skype|smb|soldat|spotify|ssh|steam|svn|teamspeak|things|udp|unreal|ut2004|ventrilo|view-source|webcal|wtai|wyciwyg|xfire|xri|ymsgr):(?:[^ [:cntrl:]<>]+))(>))'
     captures:
       1: name: 'punctuation.md'
@@ -273,7 +273,7 @@ patterns: [
 
   # auto-link: email
   {
-    name: 'email.auto.link.markup.md'
+    name: 'email.auto.link.markup.entity.md'
     match: '(<)(([a-zA-Z0-9\\.!#$%&\'\\*\\+/=?^_`{\\|}~-]+)(@)([a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*))(>)'
     captures:
       1: name: 'punctuation.md'

--- a/grammars/repositories/inlines/links.cson
+++ b/grammars/repositories/inlines/links.cson
@@ -4,7 +4,7 @@ patterns: [
   # Markdown Extra: footnote reference
   # [^1]
   {
-    name: 'reference.footnote.link.markup.md'
+    name: 'reference.footnote.link.markup.entity.md'
     match: '((?:\\[\\^)(?:[^\\[\\]]+)(?:\\]))(?!:)'
     captures:
       1: patterns: [{ include: '#link-label' }]
@@ -13,7 +13,7 @@ patterns: [
   # Markdown Extra: footnote definition
   # [^1]: And this is the footnote
   {
-    name: 'definition.footnote.link.markup.md'
+    name: 'definition.footnote.link.markup.entity.md'
     match: '((?:\\[\\^)(?:[^\\[\\]]+)(?:\\]))(:)'
     captures:
       1: patterns: [{ include: '#link-label' }]

--- a/grammars/repositories/markdown.cson
+++ b/grammars/repositories/markdown.cson
@@ -1,5 +1,5 @@
 name: 'Markdown'
-scopeName: 'text.md'
+scopeName: 'source.text.md'
 fileTypes: [
   'markdown'
   'md'

--- a/resources/markup-and-down.less
+++ b/resources/markup-and-down.less
@@ -1,0 +1,279 @@
+// 1.
+// Define colors
+
+@_background:     #ffffff;
+@_text:           #333333;
+@_syntax:         #0000ff;
+@_syntax_alt:     darken(@_syntax, 15%);
+@_content:        #009900;
+@_variable:       #0099cc;
+@_constant:       #ee1100;
+@_highlight:      #ffdd00;
+@_comment:        #ff8000;
+@_neutral:        mix(@_text, @_background);
+
+// 2.
+// Generic markup styles
+
+.source {
+  .markup {
+    &.heading {
+      color: @_syntax;
+      font-weight: bold;
+    }
+
+    &.inserted,
+    &.addition,
+    &.quote {
+      color: @_content;
+    }
+
+    &.deletion {
+      color: @_constant;
+    }
+
+    &.changed {
+      color: @_syntax;
+    }
+
+    &.list {
+      color: @_syntax_alt;
+
+      &.completed {
+        opacity: 0.333;
+      }
+    }
+
+    &.underline {
+      text-decoration: underline;
+    }
+
+    &.raw {
+      color: @neutral;
+    }
+  }
+}
+
+// 3.
+// Custom markdown styles
+
+// .text.md {
+//   .md {
+//     &.heading {
+//       color: @syntax;
+//
+//       &.empty {
+//         .punctuation {
+//           opacity: 1;
+//         }
+//       }
+//
+//       .emphasis {
+//         opacity: 1;
+//         font-weight: normal;
+//       }
+//     }
+//
+//     &.hr {
+//       color: @constant;
+//     }
+//
+//     &.quote {
+//       color: @content;
+//
+//       .link.markup,
+//       .link.text,
+//       .link.image,
+//       .string {
+//         color: @content-alt;
+//       }
+//
+//       .uri {
+//         color: @syntax-alt;
+//       }
+//     }
+//
+//     &.link {
+//       &.text {
+//         color: @content;
+//       }
+//       &.destination {
+//         color: @syntax;
+//
+//         .uri {
+//           text-decoration: underline;
+//         }
+//       }
+//       &.title {
+//         color: @syntax-alt;
+//         font-style: italic;
+//       }
+//       &.string {
+//         background: fade(@content, 5%);
+//       }
+//     }
+//
+//     &.gfm,
+//     &.reference {
+//       color: @variable;
+//       font-weight: normal;
+//     }
+//
+//     &.list {
+//       > .punctuation {
+//         opacity: 1;
+//
+//         .checkbox {
+//           color: @syntax-alt;
+//           background: fade(@syntax-alt, 10%);
+//         }
+//       }
+//       .heading {
+//         color: @syntax-alt;
+//       }
+//       &.task {
+//         &.completed {
+//           color: @text;
+//           opacity: 0.333;
+//
+//           .code {
+//             background: transparent;
+//             color: @text;
+//           }
+//
+//           .punctuation {
+//             color: @text;
+//           }
+//
+//           .todo,
+//           .review {
+//             color: inherit;
+//           }
+//
+//           .fixme {
+//             background: transparent;
+//             outline: none;
+//             color: inherit;
+//           }
+//         }
+//       }
+//       &.unordered,
+//       &.ordered
+//       {
+//         color: @text;
+//
+//         > .punctuation {
+//           color: @syntax;
+//         }
+//       }
+//       &.empty {
+//         .punctuation {
+//           color: @syntax-alt;
+//         }
+//       }
+//     }
+//
+//     &.code {
+//       color: @neutral;
+//
+//       &:not(.fenced) {
+//         background: fade(@neutral, 10%);
+//       }
+//
+//       &.fenced {
+//         &.info {
+//           color: @syntax-alt;
+//         }
+//       }
+//     }
+//
+//     &.constant {
+//       color: @constant;
+//       &.language {
+//         color: @neutral;
+//         font-weight: normal;
+//       }
+//     }
+//
+//     &.punctuation {
+//       opacity: 0.5;
+//       background: inherit;
+//     }
+//
+//     &.emphasis {
+//       font-style: italic;
+//
+//       &:not(.strong) {
+//         opacity: 0.75;
+//       }
+//
+//       &:not(.strong) .strong {
+//         font-style: italic;
+//       }
+//     }
+//
+//     &.strong {
+//       font-weight: bold;
+//       font-style: normal;
+//     }
+//
+//     &.table {
+//       color: @syntax-alt;
+//
+//       > .punctuation {
+//         color: @syntax;
+//         opacity: 0.5;
+//
+//         &.alignment {
+//           color: @syntax;
+//           opacity: 1;
+//         }
+//       }
+//     }
+//
+//     &.strike {
+//       text-decoration: line-through;
+//       opacity: 0.5;
+//     }
+//
+//     &.critic {
+//       &.addition {
+//         color: @content;
+//       }
+//       &.deletion {
+//         color: @constant;
+//       }
+//       &.comment {
+//         color: @comment;
+//         font-style: normal;
+//       }
+//       &.substitution {
+//         color: @syntax;
+//       }
+//     }
+//
+//     &.special-attributes {
+//       color: @neutral;
+//     }
+//
+//     &.special.attribute {
+//       &.other {
+//         color: inherit;
+//       }
+// 
+//       &.id,
+//       &.class
+//       {
+//         color: @constant;
+//       }
+//
+//       &.id {
+//         font-weight: bold;
+//       }
+//
+//       &.class {
+//         font-weight: normal;
+//       }
+//     }
+//   }
+// }

--- a/resources/markup-and-down.less
+++ b/resources/markup-and-down.less
@@ -208,10 +208,16 @@
 
     &.special-attributes {}
 
-    &.special.attribute {
-      &.other {}
-      &.id {}
-      &.class {}
+    &.attribute {
+      &.special {
+        &.other {}
+        &.id {}
+        &.class {}
+      }
+      .value {
+        &.string {}
+        &.storage {}
+      }
     }
   }
 }

--- a/resources/markup-and-down.less
+++ b/resources/markup-and-down.less
@@ -15,43 +15,58 @@
 // 2.
 // Generic markup styles
 
-.source {
-  .markup {
-    &.heading {
-      color: @_syntax;
-      font-weight: bold;
-    }
+.markup {
 
-    &.inserted,
-    &.addition,
-    &.quote {
-      color: @_content;
-    }
+  &.bold,
+  &.heading,
+  &.strong.emphasis {
+    font-weight: bold;
+  }
 
-    &.deletion {
-      color: @_constant;
-    }
+  &.italic,
+  &.emphasis:not(.strong) {
+    font-style: italic;
+  }
 
-    &.changed {
-      color: @_syntax;
-    }
+  &.underline {
+    text-decoration: underline;
+  }
 
-    &.list {
+  &.heading,
+  &.changed {
+    color: @_syntax;
+  }
+
+  &.inserted,
+  &.addition,
+  &.quote {
+    color: @_content;
+  }
+
+  &.deletion,
+  &.hr {
+    color: @_constant;
+  }
+
+  &.link {
+    color: @_syntax_variable;
+  }
+
+  &.list {
+    & > .punctuation {
       color: @_syntax_alt;
-
-      &.completed {
-        opacity: 0.333;
-      }
     }
 
-    &.underline {
-      text-decoration: underline;
-    }
-
-    &.raw {
-      color: @neutral;
+    &.completed {
+      opacity: 0.333;
     }
   }
+
+  &.raw,
+  &.code {
+    color: @neutral;
+  }
+
 }
 
 // 3.
@@ -260,7 +275,7 @@
 //       &.other {
 //         color: inherit;
 //       }
-// 
+//
 //       &.id,
 //       &.class
 //       {

--- a/resources/markup-and-down.less
+++ b/resources/markup-and-down.less
@@ -1,5 +1,9 @@
 // 1.
 // Define colors
+// ----------------------------------------
+// The colors below are taken from the `minimal-syntax` theme. Change them to
+// whatever you want. It's best to re-use color variables set in the rest of
+// your theme.
 
 @_background:     #ffffff;
 @_text:           #333333;
@@ -12,8 +16,11 @@
 @_comment:        #ff8000;
 @_neutral:        mix(@_text, @_background);
 
+
+
 // 2.
 // Generic markup styles
+// ----------------------------------------
 
 .markup {
 
@@ -32,7 +39,12 @@
     text-decoration: underline;
   }
 
+  &.strike {
+    text-decoration: line-through;
+  }
+
   &.heading,
+  &.substitution,
   &.changed {
     color: @_syntax;
   }
@@ -49,246 +61,157 @@
   }
 
   &.link {
-    color: @_syntax_variable;
+    color: @_variable;
   }
 
   &.list {
     & > .punctuation {
       color: @_syntax_alt;
     }
-
-    &.completed {
-      opacity: 0.333;
-    }
   }
 
   &.raw,
   &.code {
-    color: @neutral;
+    color: @_neutral;
   }
 
+ .punctuation {
+   opacity: 0.5;
+ }
 }
 
-// 3.
-// Custom markdown styles
 
-// .text.md {
-//   .md {
-//     &.heading {
-//       color: @syntax;
-//
-//       &.empty {
-//         .punctuation {
-//           opacity: 1;
-//         }
-//       }
-//
-//       .emphasis {
-//         opacity: 1;
-//         font-weight: normal;
-//       }
-//     }
-//
-//     &.hr {
-//       color: @constant;
-//     }
-//
-//     &.quote {
-//       color: @content;
-//
-//       .link.markup,
-//       .link.text,
-//       .link.image,
-//       .string {
-//         color: @content-alt;
-//       }
-//
-//       .uri {
-//         color: @syntax-alt;
-//       }
-//     }
-//
-//     &.link {
-//       &.text {
-//         color: @content;
-//       }
-//       &.destination {
-//         color: @syntax;
-//
-//         .uri {
-//           text-decoration: underline;
-//         }
-//       }
-//       &.title {
-//         color: @syntax-alt;
-//         font-style: italic;
-//       }
-//       &.string {
-//         background: fade(@content, 5%);
-//       }
-//     }
-//
-//     &.gfm,
-//     &.reference {
-//       color: @variable;
-//       font-weight: normal;
-//     }
-//
-//     &.list {
-//       > .punctuation {
-//         opacity: 1;
-//
-//         .checkbox {
-//           color: @syntax-alt;
-//           background: fade(@syntax-alt, 10%);
-//         }
-//       }
-//       .heading {
-//         color: @syntax-alt;
-//       }
-//       &.task {
-//         &.completed {
-//           color: @text;
-//           opacity: 0.333;
-//
-//           .code {
-//             background: transparent;
-//             color: @text;
-//           }
-//
-//           .punctuation {
-//             color: @text;
-//           }
-//
-//           .todo,
-//           .review {
-//             color: inherit;
-//           }
-//
-//           .fixme {
-//             background: transparent;
-//             outline: none;
-//             color: inherit;
-//           }
-//         }
-//       }
-//       &.unordered,
-//       &.ordered
-//       {
-//         color: @text;
-//
-//         > .punctuation {
-//           color: @syntax;
-//         }
-//       }
-//       &.empty {
-//         .punctuation {
-//           color: @syntax-alt;
-//         }
-//       }
-//     }
-//
-//     &.code {
-//       color: @neutral;
-//
-//       &:not(.fenced) {
-//         background: fade(@neutral, 10%);
-//       }
-//
-//       &.fenced {
-//         &.info {
-//           color: @syntax-alt;
-//         }
-//       }
-//     }
-//
-//     &.constant {
-//       color: @constant;
-//       &.language {
-//         color: @neutral;
-//         font-weight: normal;
-//       }
-//     }
-//
-//     &.punctuation {
-//       opacity: 0.5;
-//       background: inherit;
-//     }
-//
-//     &.emphasis {
-//       font-style: italic;
-//
-//       &:not(.strong) {
-//         opacity: 0.75;
-//       }
-//
-//       &:not(.strong) .strong {
-//         font-style: italic;
-//       }
-//     }
-//
-//     &.strong {
-//       font-weight: bold;
-//       font-style: normal;
-//     }
-//
-//     &.table {
-//       color: @syntax-alt;
-//
-//       > .punctuation {
-//         color: @syntax;
-//         opacity: 0.5;
-//
-//         &.alignment {
-//           color: @syntax;
-//           opacity: 1;
-//         }
-//       }
-//     }
-//
-//     &.strike {
-//       text-decoration: line-through;
-//       opacity: 0.5;
-//     }
-//
-//     &.critic {
-//       &.addition {
-//         color: @content;
-//       }
-//       &.deletion {
-//         color: @constant;
-//       }
-//       &.comment {
-//         color: @comment;
-//         font-style: normal;
-//       }
-//       &.substitution {
-//         color: @syntax;
-//       }
-//     }
-//
-//     &.special-attributes {
-//       color: @neutral;
-//     }
-//
-//     &.special.attribute {
-//       &.other {
-//         color: inherit;
-//       }
-//
-//       &.id,
-//       &.class
-//       {
-//         color: @constant;
-//       }
-//
-//       &.id {
-//         font-weight: bold;
-//       }
-//
-//       &.class {
-//         font-weight: normal;
-//       }
-//     }
-//   }
-// }
+
+// 3.
+// Define custom markdown styles
+// ----------------------------------------
+// Below is an incomplete list of markdown elements you might want to style
+// differently from the default markup elements defined above. All styles are
+// empty, primarily to give you an idea of what's possible.
+
+.text.md {
+  .md {
+
+    &.heading {
+      > .punctuation {}
+      &.empty {
+        .punctuation {}
+      }
+    }
+
+    &.hr {}
+    &.quote {}
+
+    &.link {
+      &.text {}
+      &.destination {
+        .uri {}
+      }
+      &.label {}
+      &.title {}
+      &.auto {
+        &.email {}
+      }
+      &.reference {
+        &.abbreviation {}
+      }
+      &.footnote {
+        &.reference {}
+        &.definition {}
+      }
+    }
+
+    &.gfm {
+      &.reference {
+        .mention {}
+        .issue {}
+        .user {}
+        .repository {}
+        .sha {}
+
+        &.class {}
+        &.method {
+          &.instance {}
+          &.class {}
+        }
+      }
+
+      &.emoji {}
+    }
+
+    &.constant {
+      &.entity {}
+      &.escape {}
+      &.line-break {}
+    }
+
+    &.reference {
+      &.class {}
+      &.link {}
+    }
+
+    &.list {
+      > .punctuation {
+        &.checkbox {}
+      }
+
+      &.unordered {}
+      &.ordered {}
+      &.empty {}
+
+      &.task {
+        &.completed {}
+      }
+
+      &.definition {}
+    }
+
+    &.code {
+      &:not(.fenced) {}
+
+      &.fenced {
+        &.info {}
+      }
+
+      &.raw {}
+    }
+
+    &.constant {
+      &.language {}
+    }
+
+    &.emphasis {
+      &:not(.strong) {}
+
+      &:not(.strong) .strong {
+        font-style: italic;
+      }
+    }
+
+    &.strong {}
+
+    &.table {
+      > .punctuation {
+        &.alignment {}
+      }
+    }
+
+    &.strike {}
+
+    &.critic {
+      &.addition {}
+      &.deletion {}
+      &.comment {}
+      &.highlight {}
+      &.substitution {}
+    }
+
+    &.special-attributes {}
+
+    &.special.attribute {
+      &.other {}
+      &.id {}
+      &.class {}
+    }
+  }
+}

--- a/spec/ass-spec.coffee
+++ b/spec/ass-spec.coffee
@@ -40,12 +40,12 @@ describe "Markdown grammar", ->
       atom.packages.activatePackage('language-markdown')
 
     runs ->
-      grammar = atom.grammars.grammarForScopeName('text.md')
+      grammar = atom.grammars.grammarForScopeName('source.text.md')
 
   # Test the grammar
   it "parses the grammar", ->
     expect(grammar).toBeDefined()
-    expect(grammar.scopeName).toBe "text.md"
+    expect(grammar.scopeName).toBe("source.text.md")
 
   for fixture in fixtures
 
@@ -75,7 +75,7 @@ describe "Markdown grammar", ->
           atom.packages.activatePackage('language-markdown')
 
         runs ->
-          grammar = atom.grammars.grammarForScopeName('text.md')
+          grammar = atom.grammars.grammarForScopeName('source.text.md')
 
       # Cycle through the tests we've created in ASS
       # and we need to do it in a closure apparently

--- a/spec/fixtures/blocks/fenced-code.ass
+++ b/spec/fixtures/blocks/fenced-code.ass
@@ -5,7 +5,7 @@
 "<"+
 " >"+
 "```" {
-  text.md {
+  source.text.md {
     fenced.code.md {
       "```": punctuation.md
       source.md {
@@ -22,7 +22,7 @@
 "<"+
 " >"+
 "~~~" {
-  text.md {
+  source.text.md {
     fenced.code.md {
       "~~~": punctuation.md
       source.md {
@@ -39,7 +39,7 @@
 "aaa"+
 "~~~"+
 "```" {
-  text.md {
+  source.text.md {
     fenced.code.md {
       "```": punctuation.md
       source.md {
@@ -56,7 +56,7 @@
 "aaa"+
 "```"+
 "~~~" {
-  text.md {
+  source.text.md {
     fenced.code.md {
       "~~~": punctuation.md
       source.md {
@@ -73,7 +73,7 @@
 "aaa"+
 "```"+
 "``````" {
-  text.md {
+  source.text.md {
     fenced.code.md {
       "````": punctuation.md
       source.md {
@@ -90,7 +90,7 @@
 "aaa"+
 "~~~"+
 "~~~~" {
-  text.md {
+  source.text.md {
     fenced.code.md {
       "~~~~": punctuation.md
       source.md {
@@ -104,7 +104,7 @@
 
 @83
 "```" {
-  text.md {
+  source.text.md {
     fenced.code.md {
       "```": punctuation.md
     }
@@ -116,7 +116,7 @@
 ""+
 "```"+
 "aaa" {
-  text.md {
+  source.text.md {
     fenced.code.md {
       "`````": punctuation.md
       source.md {
@@ -135,7 +135,7 @@
 "> aaa"+
 ""+
 "bbb" {
-  text.md {
+  source.text.md {
     quote.markup.md {
       ">": punctuation.md
       " "
@@ -163,7 +163,7 @@
 "    ```"+
 "    aaa"+
 "    ```" {
-  text.md {
+  source.text.md {
     "    ```"
     "    aaa"
     "    ```"
@@ -184,7 +184,7 @@
 @95
 "``` ```"+
 "aaa" {
-  text.md {
+  source.text.md {
     "``` ```"
     "aaa"
   }
@@ -194,7 +194,7 @@
 "~~~~~~"+
 "aaa"+
 "~~~ ~~" {
-  text.md {
+  source.text.md {
     fenced.code.md {
       "~~~~~~": punctuation.md
       source.md {
@@ -211,7 +211,7 @@
 "bar"+
 "```"+
 "baz" {
-  text.md {
+  source.text.md {
     "foo"
     fenced.code.md {
       "```": punctuation.md
@@ -231,7 +231,7 @@
 "bar"+
 "~~~"+
 "# baz" {
-  text.md {
+  source.text.md {
     "foo"
     "---": hr.md
     fenced.code.md {
@@ -257,7 +257,7 @@
 "  return 3"+
 "end"+
 "```" {
-  text.md {
+  source.text.md {
     fenced.code.md {
       "```": punctuation.md
       "ruby": language.constant.md
@@ -278,7 +278,7 @@
 "  return 3"+
 "end"+
 "~~~~~~~" {
-  text.md {
+  source.text.md {
     fenced.code.md {
       "~~~~~~~": punctuation.md
       " "
@@ -306,7 +306,7 @@
 # @101
 # "````;"+
 # "````" {
-#   text.md {
+#   source.text.md {
 #     fenced.code.md {
 #       "````": punctuation.md
 #       ";"
@@ -323,7 +323,7 @@
 "```"+
 "``` aaa"+
 "```" {
-  text.md {
+  source.text.md {
     fenced.code.md {
       "```": punctuation.md
       source.md {

--- a/spec/fixtures/blocks/fenced-code.ass
+++ b/spec/fixtures/blocks/fenced-code.ass
@@ -233,7 +233,7 @@
 "# baz" {
   source.text.md {
     "foo"
-    "---": hr.md
+    "---": hr.constant.markup.md
     fenced.code.md {
       "~~~": punctuation.md
       source.md {
@@ -241,7 +241,7 @@
       }
       "~~~": punctuation.md
     }
-    heading.markup.md {
+    heading.support.markup.md {
       heading-1.md {
         "#": punctuation.md
         " "

--- a/spec/fixtures/blocks/headings.ass
+++ b/spec/fixtures/blocks/headings.ass
@@ -2,7 +2,7 @@
 @27
 '# Heading' {
   source.text.md {
-    heading.markup.md {
+    heading.support.markup.md {
       heading-1.md {
         '#': punctuation.md
         ' '
@@ -48,7 +48,7 @@
 @31
 '# foo *bar* \*baz\*' {
   source.text.md {
-    heading.markup.md {
+    heading.support.markup.md {
       heading-1.md {
         '#': punctuation.md
         ' '
@@ -71,7 +71,7 @@
 @32
 '#                  foo' {
   source.text.md {
-    heading.markup.md {
+    heading.support.markup.md {
       heading-1.md {
         '#': punctuation.md
         '                  '
@@ -85,7 +85,7 @@
 @33
 '  ## Heading' {
   source.text.md {
-    heading.markup.md {
+    heading.support.markup.md {
       heading-2.md {
         '  '
         '##': punctuation.md
@@ -106,7 +106,7 @@
 @36a
 '## foo ##' {
   source.text.md {
-    heading.markup.md {
+    heading.support.markup.md {
       heading-2.md {
         '##': punctuation.md
         ' '
@@ -121,7 +121,7 @@
 @36b
 '  ###   bar    ###' {
   source.text.md {
-    heading.markup.md {
+    heading.support.markup.md {
       heading-3.md {
         '  '
         '###': punctuation.md
@@ -138,7 +138,7 @@
 @37a
 '# foo ##################################' {
   source.text.md {
-    heading.markup.md {
+    heading.support.markup.md {
       heading-1.md {
         '#': punctuation.md
         ' '
@@ -153,7 +153,7 @@
 @37b
 '##### foo ##' {
   source.text.md {
-    heading.markup.md {
+    heading.support.markup.md {
       heading-5.md {
         '#####': punctuation.md
         ' '
@@ -169,7 +169,7 @@
 @38
 '### foo ###     ' {
   source.text.md {
-    heading.markup.md {
+    heading.support.markup.md {
       heading-3.md {
         '###': punctuation.md
         ' '
@@ -186,7 +186,7 @@
 @39
 '### foo ### b' {
   source.text.md {
-    heading.markup.md {
+    heading.support.markup.md {
       heading-3.md {
         '###': punctuation.md
         ' '
@@ -200,7 +200,7 @@
 @40
 '# foo#' {
   source.text.md {
-    heading.markup.md {
+    heading.support.markup.md {
       heading-1.md {
         '#': punctuation.md
         ' '
@@ -220,7 +220,7 @@
 @41b
 '## foo #\##' {
   source.text.md {
-    heading.markup.md {
+    heading.support.markup.md {
       heading-2.md {
         '##': punctuation.md
         ' '
@@ -241,7 +241,7 @@
 @44a
 '## ' {
   source.text.md {
-    empty.heading.markup.md {
+    empty.heading.support.markup.md {
       heading-2.md {
         '##': punctuation.md
         ' '
@@ -253,7 +253,7 @@
 @44b
 '#' {
   source.text.md {
-    empty.heading.markup.md {
+    empty.heading.support.markup.md {
       heading-1.md {
         '#': punctuation.md
       }
@@ -264,7 +264,7 @@
 @44c
 '### ###' {
   source.text.md {
-    empty.heading.markup.md {
+    empty.heading.support.markup.md {
       heading-3.md {
         '###': punctuation.md
         ' '

--- a/spec/fixtures/blocks/headings.ass
+++ b/spec/fixtures/blocks/headings.ass
@@ -1,7 +1,7 @@
 # http://spec.commonmark.org/0.22/#example-27
 @27
 '# Heading' {
-  text.md {
+  source.text.md {
     heading.markup.md {
       heading-1.md {
         '#': punctuation.md
@@ -15,13 +15,13 @@
 # http://spec.commonmark.org/0.22/#example-28
 @28
 '####### foo' {
-  '####### foo': text.md
+  '####### foo': source.text.md
 }
 
 # http://spec.commonmark.org/0.22/#example-29
 @29a
 '#5 bolt' {
-  text.md {
+  source.text.md {
     reference.gfm.variable.md {
       '#': punctuation.md
       '5': issue.gfm.md
@@ -32,13 +32,13 @@
 
 @29b
 '#foobar' {
-  '#foobar': text.md
+  '#foobar': source.text.md
 }
 
 # http://spec.commonmark.org/0.22/#example-30
 @30
 '\## foo' {
-  text.md {
+  source.text.md {
     '\#': escape.constant.md
     '# foo'
   }
@@ -47,7 +47,7 @@
 # http://spec.commonmark.org/0.22/#example-31
 @31
 '# foo *bar* \*baz\*' {
-  text.md {
+  source.text.md {
     heading.markup.md {
       heading-1.md {
         '#': punctuation.md
@@ -70,7 +70,7 @@
 # http://spec.commonmark.org/0.22/#example-32
 @32
 '#                  foo' {
-  text.md {
+  source.text.md {
     heading.markup.md {
       heading-1.md {
         '#': punctuation.md
@@ -84,7 +84,7 @@
 # http://spec.commonmark.org/0.22/#example-33
 @33
 '  ## Heading' {
-  text.md {
+  source.text.md {
     heading.markup.md {
       heading-2.md {
         '  '
@@ -105,7 +105,7 @@
 # http://spec.commonmark.org/0.22/#example-36
 @36a
 '## foo ##' {
-  text.md {
+  source.text.md {
     heading.markup.md {
       heading-2.md {
         '##': punctuation.md
@@ -120,7 +120,7 @@
 
 @36b
 '  ###   bar    ###' {
-  text.md {
+  source.text.md {
     heading.markup.md {
       heading-3.md {
         '  '
@@ -137,7 +137,7 @@
 # http://spec.commonmark.org/0.22/#example-37
 @37a
 '# foo ##################################' {
-  text.md {
+  source.text.md {
     heading.markup.md {
       heading-1.md {
         '#': punctuation.md
@@ -152,7 +152,7 @@
 
 @37b
 '##### foo ##' {
-  text.md {
+  source.text.md {
     heading.markup.md {
       heading-5.md {
         '#####': punctuation.md
@@ -168,7 +168,7 @@
 # http://spec.commonmark.org/0.22/#example-38
 @38
 '### foo ###     ' {
-  text.md {
+  source.text.md {
     heading.markup.md {
       heading-3.md {
         '###': punctuation.md
@@ -185,7 +185,7 @@
 # http://spec.commonmark.org/0.22/#example-39
 @39
 '### foo ### b' {
-  text.md {
+  source.text.md {
     heading.markup.md {
       heading-3.md {
         '###': punctuation.md
@@ -199,7 +199,7 @@
 # http://spec.commonmark.org/0.22/#example-40
 @40
 '# foo#' {
-  text.md {
+  source.text.md {
     heading.markup.md {
       heading-1.md {
         '#': punctuation.md
@@ -219,7 +219,7 @@
 
 @41b
 '## foo #\##' {
-  text.md {
+  source.text.md {
     heading.markup.md {
       heading-2.md {
         '##': punctuation.md
@@ -240,7 +240,7 @@
 # http://spec.commonmark.org/0.22/#example-44
 @44a
 '## ' {
-  text.md {
+  source.text.md {
     empty.heading.markup.md {
       heading-2.md {
         '##': punctuation.md
@@ -252,7 +252,7 @@
 
 @44b
 '#' {
-  text.md {
+  source.text.md {
     empty.heading.markup.md {
       heading-1.md {
         '#': punctuation.md
@@ -263,7 +263,7 @@
 
 @44c
 '### ###' {
-  text.md {
+  source.text.md {
     empty.heading.markup.md {
       heading-3.md {
         '###': punctuation.md

--- a/spec/fixtures/blocks/hr.ass
+++ b/spec/fixtures/blocks/hr.ass
@@ -2,7 +2,7 @@
 @8a
 "***" {
   source.text.md {
-    '***': hr.md
+    '***': hr.constant.markup.md
   }
 }
 
@@ -17,7 +17,7 @@
 "---" {
   source.text.md {
     front-matter.yaml.source.md {
-      '---': hr.md
+      '---': hr.constant.markup.md
     }
   }
 }
@@ -25,7 +25,7 @@
 @8c
 "___" {
   source.text.md {
-    '___': hr.md
+    '___': hr.constant.markup.md
   }
 }
 
@@ -34,7 +34,7 @@
 "---" {
   source.text.md {
     " "
-    '---': hr.md
+    '---': hr.constant.markup.md
   }
 }
 
@@ -43,7 +43,7 @@
 "+++" {
   source.text.md {
     front-matter.toml.source.md {
-      '+++': hr.md
+      '+++': hr.constant.markup.md
     }
   }
 }
@@ -72,7 +72,7 @@
 @12c
 "   ***" {
   source.text.md {
-    '   ***': hr.md
+    '   ***': hr.constant.markup.md
   }
 }
 
@@ -88,7 +88,7 @@
 @15
 "_____________________________________" {
   source.text.md {
-    "_____________________________________": hr.md
+    "_____________________________________": hr.constant.markup.md
   }
 }
 
@@ -96,7 +96,7 @@
 @16
 " - - -" {
   source.text.md {
-    " - - -": hr.md
+    " - - -": hr.constant.markup.md
   }
 }
 
@@ -104,7 +104,7 @@
 @17
 " **  * ** * ** * **" {
   source.text.md {
-    " **  * ** * ** * **": hr.md
+    " **  * ** * ** * **": hr.constant.markup.md
   }
 }
 
@@ -112,7 +112,7 @@
 @18
 "-     -      -      -" {
   source.text.md {
-    "-     -      -      -": hr.md
+    "-     -      -      -": hr.constant.markup.md
   }
 }
 
@@ -120,7 +120,7 @@
 @19
 "- - - -    " {
   source.text.md {
-    "- - - -    ": hr.md
+    "- - - -    ": hr.constant.markup.md
   }
 }
 
@@ -162,7 +162,7 @@
       "* ": punctuation.md
       "Foo"
     }
-    "* * *": hr.md
+    "* * *": hr.constant.markup.md
     unordered.list.markup.md {
       "* ": punctuation.md
       "Bar"
@@ -179,7 +179,7 @@
       "- ": punctuation.md
       "Foo"
       "- ": punctuation.md
-      "* * *": hr.md
+      "* * *": hr.constant.markup.md
     }
   }
 }

--- a/spec/fixtures/blocks/hr.ass
+++ b/spec/fixtures/blocks/hr.ass
@@ -1,7 +1,7 @@
 # http://spec.commonmark.org/0.22/#example-8
 @8a
 "***" {
-  text.md {
+  source.text.md {
     '***': hr.md
   }
 }
@@ -15,7 +15,7 @@
 
 @8b
 "---" {
-  text.md {
+  source.text.md {
     front-matter.yaml.source.md {
       '---': hr.md
     }
@@ -24,7 +24,7 @@
 
 @8c
 "___" {
-  text.md {
+  source.text.md {
     '___': hr.md
   }
 }
@@ -32,7 +32,7 @@
 @8d
 " "+
 "---" {
-  text.md {
+  source.text.md {
     " "
     '---': hr.md
   }
@@ -41,7 +41,7 @@
 # http://spec.commonmark.org/0.22/#example-9
 @9
 "+++" {
-  text.md {
+  source.text.md {
     front-matter.toml.source.md {
       '+++': hr.md
     }
@@ -50,17 +50,17 @@
 
 # http://spec.commonmark.org/0.22/#example-10
 @10
-"===": text.md
+"===": source.text.md
 
 # http://spec.commonmark.org/0.22/#example-11
 @11a
-"--": text.md
+"--": source.text.md
 
 @11b
-"**": text.md
+"**": source.text.md
 
 @11c
-"__": text.md
+"__": source.text.md
 
 # http://spec.commonmark.org/0.22/#example-12
 
@@ -71,14 +71,14 @@
 
 @12c
 "   ***" {
-  text.md {
+  source.text.md {
     '   ***': hr.md
   }
 }
 
 # http://spec.commonmark.org/0.22/#example-13
 @13
-"    ***": text.md
+"    ***": source.text.md
 
 # NOTE
 # Removed @14, because it is not related to syntax highlighting
@@ -87,7 +87,7 @@
 # http://spec.commonmark.org/0.22/#example-15
 @15
 "_____________________________________" {
-  text.md {
+  source.text.md {
     "_____________________________________": hr.md
   }
 }
@@ -95,7 +95,7 @@
 # http://spec.commonmark.org/0.22/#example-16
 @16
 " - - -" {
-  text.md {
+  source.text.md {
     " - - -": hr.md
   }
 }
@@ -103,7 +103,7 @@
 # http://spec.commonmark.org/0.22/#example-17
 @17
 " **  * ** * ** * **" {
-  text.md {
+  source.text.md {
     " **  * ** * ** * **": hr.md
   }
 }
@@ -111,7 +111,7 @@
 # http://spec.commonmark.org/0.22/#example-18
 @18
 "-     -      -      -" {
-  text.md {
+  source.text.md {
     "-     -      -      -": hr.md
   }
 }
@@ -119,14 +119,14 @@
 # http://spec.commonmark.org/0.22/#example-19
 @19
 "- - - -    " {
-  text.md {
+  source.text.md {
     "- - - -    ": hr.md
   }
 }
 
 # http://spec.commonmark.org/0.22/#example-20
 @20a
-"_ _ _ _ a": text.md
+"_ _ _ _ a": source.text.md
 
 # NOTE
 # Removed @20b, because it is too similar to @20a
@@ -136,7 +136,7 @@
 # http://spec.commonmark.org/0.22/#example-21
 @21
 " *-*" {
-  text.md {
+  source.text.md {
     " "
     emphasis.italic.markup.md {
       "*": punctuation.md
@@ -157,7 +157,7 @@
 "* Foo"+
 "* * *"+
 "* Bar" {
-  text.md {
+  source.text.md {
     unordered.list.markup.md {
       "* ": punctuation.md
       "Foo"
@@ -174,7 +174,7 @@
 @26
 "- Foo"+
 "- * * *" {
-  text.md {
+  source.text.md {
     unordered.list.markup.md {
       "- ": punctuation.md
       "Foo"

--- a/spec/fixtures/blocks/link-references.ass
+++ b/spec/fixtures/blocks/link-references.ass
@@ -4,7 +4,7 @@
 "[foo]" {
   source.text.md {
     "[foo]: /url "title"" {
-      reference.link.markup.md {
+      reference.link.markup.entity.md {
         "[foo]" {
           label.link.string.md {
             "[": punctuation.md
@@ -21,7 +21,7 @@
         }
         " "
         ""title"" {
-          title.link.md {
+          title.link.meta.md {
             '"': punctuation.md
             "title"
             '"': punctuation.md
@@ -82,7 +82,7 @@
   source.text.md {
     "[foo]: /url '" {
       "[foo]: /url" {
-        reference.link.markup.md {
+        reference.link.markup.entity.md {
           "[foo]" {
             label.link.string.md {
               "[": punctuation.md
@@ -116,7 +116,7 @@
   source.text.md {
     "[foo]: /url 'title" {
       "[foo]: /url" {
-        reference.link.markup.md {
+        reference.link.markup.entity.md {
           "[foo]" {
             label.link.string.md {
               "[": punctuation.md
@@ -174,7 +174,7 @@
     }
     ""
     "[foo]: url" {
-      reference.link.markup.md {
+      reference.link.markup.entity.md {
         "[foo]" {
           label.link.string.md {
             "[": punctuation.md
@@ -205,7 +205,7 @@
 "[αγω]" {
   source.text.md {
     "[ΑΓΩ]: /φου" {
-      reference.link.markup.md {
+      reference.link.markup.entity.md {
         "[ΑΓΩ]" {
           label.link.string.md {
             "[": punctuation.md
@@ -237,7 +237,7 @@
 "[foo]: /url" {
   source.text.md {
     "[foo]: /url" {
-      reference.link.markup.md {
+      reference.link.markup.entity.md {
         "[foo]" {
           label.link.string.md {
             "[": punctuation.md
@@ -274,7 +274,7 @@
 "[foo]: /url "title" ok" {
   source.text.md {
     "[foo]: /url "title"" {
-      reference.link.markup.md {
+      reference.link.markup.entity.md {
         "[foo]" {
           label.link.string.md {
             "[": punctuation.md
@@ -291,7 +291,7 @@
         }
         " "
         ""title"" {
-          title.link.md {
+          title.link.meta.md {
             '"': punctuation.md
             "title"
             '"': punctuation.md
@@ -308,7 +308,7 @@
 ""title" ok" {
   source.text.md {
     "[foo]: /url" {
-      reference.link.markup.md {
+      reference.link.markup.entity.md {
         "[foo]" {
           label.link.string.md {
             "[": punctuation.md
@@ -334,7 +334,7 @@
   source.text.md {
     "    "
     "[foo]: /url "title"" {
-      reference.link.markup.md {
+      reference.link.markup.entity.md {
         "[foo]" {
           label.link.string.md {
             "[": punctuation.md
@@ -351,7 +351,7 @@
         }
         " "
         ""title"" {
-          title.link.md {
+          title.link.meta.md {
             '"': punctuation.md
             "title"
             '"': punctuation.md
@@ -384,7 +384,7 @@
   source.text.md {
     "Foo"
     "[bar]: /baz" {
-      reference.link.markup.md {
+      reference.link.markup.entity.md {
         "[bar]" {
           label.link.string.md {
             "[": punctuation.md
@@ -407,7 +407,7 @@
 @166
 "# [Foo]" {
   source.text.md {
-    heading.markup.md {
+    heading.support.markup.md {
       heading-1.md {
         "#": punctuation.md
         " "
@@ -434,7 +434,7 @@
 "[baz]" {
   source.text.md {
     "[foo]: /foo-url "foo"" {
-      reference.link.markup.md {
+      reference.link.markup.entity.md {
         "[foo]" {
           label.link.string.md {
             "[": punctuation.md
@@ -451,7 +451,7 @@
         }
         " "
         ""foo"" {
-          title.link.md {
+          title.link.meta.md {
             '"': punctuation.md
             "foo"
             '"': punctuation.md
@@ -460,7 +460,7 @@
       }
     }
     "[bar]: /bar-url" {
-      reference.link.markup.md {
+      reference.link.markup.entity.md {
         "[bar]" {
           label.link.string.md {
             "[": punctuation.md
@@ -479,7 +479,7 @@
     }
     "  "bar""
     "[baz]: /baz-url" {
-      reference.link.markup.md {
+      reference.link.markup.entity.md {
         "[baz]" {
           label.link.string.md {
             "[": punctuation.md
@@ -530,7 +530,7 @@
       quote.markup.md {
         ">": punctuation.md
         " "
-        reference.link.markup.md {
+        reference.link.markup.entity.md {
           "[foo]" {
             label.link.string.md {
               "[": punctuation.md

--- a/spec/fixtures/blocks/link-references.ass
+++ b/spec/fixtures/blocks/link-references.ass
@@ -2,7 +2,7 @@
 "[foo]: /url "title""+
 ""+
 "[foo]" {
-  text.md {
+  source.text.md {
     "[foo]: /url "title"" {
       reference.link.markup.md {
         "[foo]" {
@@ -45,7 +45,7 @@
 "[foo]:"+
 "   /url"+
 "        'the title'" {
-  text.md {
+  source.text.md {
     "[foo]:"
     "   /url"
     "        'the title'"
@@ -65,7 +65,7 @@
 "[Foo bar]:"+
 "<my url>"+
 "'title'" {
-  text.md {
+  source.text.md {
     "[Foo bar]:"
     "<my url>"
     "'title'"
@@ -79,7 +79,7 @@
 "line1"+
 "line2"+
 "'" {
-  text.md {
+  source.text.md {
     "[foo]: /url '" {
       "[foo]: /url" {
         reference.link.markup.md {
@@ -113,7 +113,7 @@
 "[foo]: /url 'title"+
 ""+
 "with blank line'" {
-  text.md {
+  source.text.md {
     "[foo]: /url 'title" {
       "[foo]: /url" {
         reference.link.markup.md {
@@ -143,14 +143,14 @@
 @152
 "[foo]:"+
 "/url" {
-  text.md {
+  source.text.md {
     "[foo]:"
     "/url"
   }
 }
 
 @153
-"[foo]:": text.md
+"[foo]:": source.text.md
 
 # TODO
 # @154
@@ -164,7 +164,7 @@
 "[foo]"+
 ""+
 "[foo]: url" {
-  text.md {
+  source.text.md {
     "[foo]" {
       label.link.string.md {
         "[": punctuation.md
@@ -203,7 +203,7 @@
 "[ΑΓΩ]: /φου"+
 ""+
 "[αγω]" {
-  text.md {
+  source.text.md {
     "[ΑΓΩ]: /φου" {
       reference.link.markup.md {
         "[ΑΓΩ]" {
@@ -235,7 +235,7 @@
 
 @159
 "[foo]: /url" {
-  text.md {
+  source.text.md {
     "[foo]: /url" {
       reference.link.markup.md {
         "[foo]" {
@@ -262,7 +262,7 @@
 "foo"+
 "]: /url"+
 "bar" {
-  text.md {
+  source.text.md {
     "["
     "foo"
     "]: /url"
@@ -272,7 +272,7 @@
 
 @161
 "[foo]: /url "title" ok" {
-  text.md {
+  source.text.md {
     "[foo]: /url "title"" {
       reference.link.markup.md {
         "[foo]" {
@@ -306,7 +306,7 @@
 @162
 "[foo]: /url"+
 ""title" ok" {
-  text.md {
+  source.text.md {
     "[foo]: /url" {
       reference.link.markup.md {
         "[foo]" {
@@ -331,7 +331,7 @@
 
 @163
 "    [foo]: /url "title"" {
-  text.md {
+  source.text.md {
     "    "
     "[foo]: /url "title"" {
       reference.link.markup.md {
@@ -366,7 +366,7 @@
 "```"+
 "[foo]: /url"+
 "```" {
-  text.md {
+  source.text.md {
     fenced.code.md {
       "```": punctuation.md
       source.md {
@@ -381,7 +381,7 @@
 @165
 "Foo"+
 "[bar]: /baz" {
-  text.md {
+  source.text.md {
     "Foo"
     "[bar]: /baz" {
       reference.link.markup.md {
@@ -406,7 +406,7 @@
 
 @166
 "# [Foo]" {
-  text.md {
+  source.text.md {
     heading.markup.md {
       heading-1.md {
         "#": punctuation.md
@@ -432,7 +432,7 @@
 "[foo],"+
 "[bar],"+
 "[baz]" {
-  text.md {
+  source.text.md {
     "[foo]: /foo-url "foo"" {
       reference.link.markup.md {
         "[foo]" {
@@ -525,7 +525,7 @@
 
 @168
 "> [foo]: /url" {
-  text.md {
+  source.text.md {
     "> [foo]: /url" {
       quote.markup.md {
         ">": punctuation.md

--- a/spec/fixtures/blocks/lists.ass
+++ b/spec/fixtures/blocks/lists.ass
@@ -9,7 +9,7 @@
 "- one"+
 ""+
 "  two" {
-  text.md {
+  source.text.md {
     unordered.list.markup.md {
       '- ': punctuation.md
       'one'
@@ -23,7 +23,7 @@
 "-one"+
 ""+
 "2.two" {
-  text.md {
+  source.text.md {
     "-one"
     ""
     "2.two"
@@ -32,7 +32,7 @@
 
 @214
 '123456789. ok' {
-  text.md {
+  source.text.md {
     ordered.list.markup.md {
       '123456789. ': punctuation.md
       'ok'
@@ -41,11 +41,11 @@
 }
 
 @215
-'1234567890. not ok': text.md
+'1234567890. not ok': source.text.md
 
 @216
 '0. ok' {
-  text.md {
+  source.text.md {
     ordered.list.markup.md {
       '0. ': punctuation.md
       'ok'
@@ -55,7 +55,7 @@
 
 @217
 "003. ok" {
-  text.md {
+  source.text.md {
     ordered.list.markup.md {
       '003. ': punctuation.md
       'ok'
@@ -64,7 +64,7 @@
 }
 
 @218
-"-1. not ok": text.md
+"-1. not ok": source.text.md
 
 # NOTE
 # Removed @219, because it is not related to syntax highlighting
@@ -75,7 +75,7 @@
 "- foo"+
 "-"+
 "- bar" {
-  text.md {
+  source.text.md {
     unordered.list.markup.md {
       '- ': punctuation.md
       'foo'
@@ -98,7 +98,7 @@
 "1. foo"+
 "2."+
 "3. bar" {
-  text.md {
+  source.text.md {
     ordered.list.markup.md {
       '1. ': punctuation.md
       'foo'
@@ -115,7 +115,7 @@
 
 @232
 "*" {
-  text.md {
+  source.text.md {
     empty.unordered.list.markup.md {
       '*': punctuation.md
     }
@@ -125,7 +125,7 @@
 @240
 "> 1. > Blockquote"+
 "> continued here." {
-  text.md {
+  source.text.md {
     quote.markup.md {
       ">": punctuation.md
       " "
@@ -153,7 +153,7 @@
 
 @245
 "- - foo" {
-  text.md {
+  source.text.md {
     unordered.list.markup.md {
       "- ": punctuation.md
       unordered.list.markup.md {
@@ -166,7 +166,7 @@
 
 @246
 "1. - 2. foo" {
-  text.md {
+  source.text.md {
     ordered.list.markup.md {
       "1. ": punctuation.md
       unordered.list.markup.md {
@@ -185,7 +185,7 @@
 "- Bar"+
 "  ---"+
 "  baz" {
-  text.md {
+  source.text.md {
     unordered.list.markup.md {
       "- ": punctuation.md
       heading.markup.md {
@@ -212,7 +212,7 @@
 @251
 "The number of windows in my house is"+
 "14.  The number of doors is 6." {
-  text.md {
+  source.text.md {
     "The number of windows in my house is"
     ordered.list.markup.md {
       "14. ": punctuation.md
@@ -235,7 +235,7 @@
 "  > b"+
 "  >"+
 "* c" {
-  text.md {
+  source.text.md {
     unordered.list.markup.md {
       "* ": punctuation.md
       "a"

--- a/spec/fixtures/blocks/lists.ass
+++ b/spec/fixtures/blocks/lists.ass
@@ -188,7 +188,7 @@
   source.text.md {
     unordered.list.markup.md {
       "- ": punctuation.md
-      heading.markup.md {
+      heading.support.markup.md {
         heading-1.md {
           "#": punctuation.md
           " "
@@ -198,7 +198,7 @@
       "- ": punctuation.md
       "Bar"
     }
-    "  ---": hr.md
+    "  ---": hr.constant.markup.md
     "  baz"
   }
 }

--- a/spec/fixtures/blocks/quotes.ass
+++ b/spec/fixtures/blocks/quotes.ass
@@ -4,7 +4,7 @@
 '> # Foo'+
 '> bar'+
 '> baz' {
-  text.md {
+  source.text.md {
     quote.markup.md {
       '>': punctuation.md
       ' '
@@ -29,7 +29,7 @@
 "># Foo"+
 ">bar"+
 "> baz" {
-  text.md {
+  source.text.md {
     quote.markup.md {
       '>': punctuation.md
       heading.markup.md {
@@ -52,7 +52,7 @@
 "   > # Foo"+
 "   > bar"+
 " > baz" {
-  text.md {
+  source.text.md {
     quote.markup.md {
       "   "
       '>': punctuation.md
@@ -80,7 +80,7 @@
 "    > # Foo"+
 "    > bar"+
 "    > baz" {
-  text.md {
+  source.text.md {
     "    > # Foo"
     "    > bar"
     "    > baz"
@@ -94,7 +94,7 @@
 @186
 ">     foo"+
 "    bar" {
-  text.md {
+  source.text.md {
     quote.markup.md {
       '>': punctuation.md
       ' '
@@ -109,7 +109,7 @@
 "> ```"+
 "foo"+
 "```" {
-  text.md {
+  source.text.md {
     quote.markup.md {
       '>': punctuation.md
       ' '
@@ -127,7 +127,7 @@
 @188
 "> foo"+
 "    - bar" {
-  text.md {
+  source.text.md {
     quote.markup.md {
       '>': punctuation.md
       ' '
@@ -143,7 +143,7 @@
 
 @189
 ">" {
-  text.md {
+  source.text.md {
     quote.markup.md {
       '>': punctuation.md
     }
@@ -154,7 +154,7 @@
 ">"+
 ">  "+
 "> " {
-  text.md {
+  source.text.md {
     quote.markup.md {
       '>': punctuation.md
       '>': punctuation.md
@@ -170,7 +170,7 @@
 ">"+
 "> foo"+
 ">  " {
-  text.md {
+  source.text.md {
     quote.markup.md {
       '>': punctuation.md
       '>': punctuation.md
@@ -190,7 +190,7 @@
 @200
 "> > > foo"+
 "bar" {
-  text.md {
+  source.text.md {
     quote.markup.md {
       '>': punctuation.md
       ' '
@@ -212,7 +212,7 @@
 ">>> foo"+
 "> bar"+
 ">>baz" {
-  text.md {
+  source.text.md {
     quote.markup.md {
       '>': punctuation.md
       quote.markup.md {
@@ -239,7 +239,7 @@
 ">     code"+
 ""+
 ">    not code" {
-  text.md {
+  source.text.md {
     quote.markup.md {
       '>': punctuation.md
       ' '

--- a/spec/fixtures/blocks/quotes.ass
+++ b/spec/fixtures/blocks/quotes.ass
@@ -8,7 +8,7 @@
     quote.markup.md {
       '>': punctuation.md
       ' '
-      heading.markup.md {
+      heading.support.markup.md {
         heading-1.md {
           '#': punctuation.md
           ' '
@@ -32,7 +32,7 @@
   source.text.md {
     quote.markup.md {
       '>': punctuation.md
-      heading.markup.md {
+      heading.support.markup.md {
         heading-1.md {
           '#': punctuation.md
           ' '
@@ -57,7 +57,7 @@
       "   "
       '>': punctuation.md
       " "
-      heading.markup.md {
+      heading.support.markup.md {
         heading-1.md {
           '#': punctuation.md
           ' '

--- a/spec/fixtures/flavors/criticmark.ass
+++ b/spec/fixtures/flavors/criticmark.ass
@@ -2,7 +2,7 @@
 
 @1a
 "{++Chocolate++}" {
-  text.md {
+  source.text.md {
     addition.critic.inserted.markup.md {
       "{++": punctuation.md
       "Chocolate"
@@ -13,7 +13,7 @@
 
 @1b
 "{++_Lots of_ chocolate++}" {
-  text.md {
+  source.text.md {
     addition.critic.inserted.markup.md {
       "{++": punctuation.md
       "_Lots of_" {
@@ -31,7 +31,7 @@
 
 @2
 "{--Hunger--}" {
-  text.md {
+  source.text.md {
     deletion.critic.deleted.markup.md {
       "{--": punctuation.md
       "Hunger"
@@ -42,7 +42,7 @@
 
 @3
 "{~~Sadness~>Love~~}" {
-  text.md {
+  source.text.md {
     substitution.critic.inserted.markup.md {
       "{~~": punctuation.md
       "Sadness"
@@ -55,7 +55,7 @@
 
 @4
 "{>>No comment<<}" {
-  text.md {
+  source.text.md {
     comment.critic.markup.md {
       "{>>": punctuation.md
       "No comment"
@@ -66,7 +66,7 @@
 
 @5a
 "{==Yellow marker==}" {
-  text.md {
+  source.text.md {
     highlight.critic.changed.markup.md {
       "{==": punctuation.md
       "Yellow marker"
@@ -77,7 +77,7 @@
 
 @5b
 "{==Yellow marker==}{>>@burodepeper<<}" {
-  text.md {
+  source.text.md {
     "{==Yellow marker==}" {
       highlight.critic.changed.markup.md {
         "{==": punctuation.md

--- a/spec/fixtures/flavors/github/atomdoc.ass
+++ b/spec/fixtures/flavors/github/atomdoc.ass
@@ -1,6 +1,6 @@
 @1
 "The {String} name of the package to disable." {
-  text.md {
+  source.text.md {
     "The "
     "{String}" {
       class.reference.gfm.variable.md {
@@ -15,7 +15,7 @@
 
 @2
 "{ClassName::methodName}" {
-  text.md {
+  source.text.md {
     instance.method.reference.gfm.variable.md {
       "{": punctuation.md
       "ClassName"
@@ -28,7 +28,7 @@
 
 @3
 "{ClassName.methodName}" {
-  text.md {
+  source.text.md {
     class.method.reference.gfm.variable.md {
       "{": punctuation.md
       "ClassName"
@@ -40,10 +40,10 @@
 }
 
 @4
-"{className}": text.md
+"{className}": source.text.md
 
 @5
-"{className::MethodName}": text.md
+"{className::MethodName}": source.text.md
 
 @6
-"{className.MethodName}": text.md
+"{className.MethodName}": source.text.md

--- a/spec/fixtures/flavors/github/emojis.ass
+++ b/spec/fixtures/flavors/github/emojis.ass
@@ -1,6 +1,6 @@
 @1
 ":+1:" {
-  text.md {
+  source.text.md {
     emoji.constant.gfm.md {
       ":": punctuation.md
       "+1"
@@ -10,20 +10,20 @@
 }
 
 @2
-":david:": text.md
+":david:": source.text.md
 
 @3
-":david is awesome:": text.md
+":david is awesome:": source.text.md
 
 @4
-":arrow_UP:": text.md
+":arrow_UP:": source.text.md
 
 @5
-"david:+1:": text.md
+"david:+1:": source.text.md
 
 @6
 "david :+1:" {
-  text.md {
+  source.text.md {
     "david "
     emoji.constant.gfm.md {
       ":": punctuation.md

--- a/spec/fixtures/flavors/github/issues.ass
+++ b/spec/fixtures/flavors/github/issues.ass
@@ -1,6 +1,6 @@
 @1
 "#123" {
-  text.md {
+  source.text.md {
     "#123" {
       reference.gfm.variable.md {
         "#": punctuation.md
@@ -12,7 +12,7 @@
 
 @2
 "#12.3" {
-  text.md {
+  source.text.md {
     "#12" {
       reference.gfm.variable.md {
         "#": punctuation.md
@@ -24,11 +24,11 @@
 }
 
 @3
-"123#456": text.md
+"123#456": source.text.md
 
 @4
 "#123: something, something" {
-  text.md {
+  source.text.md {
     "#123" {
       reference.gfm.variable.md {
         "#": punctuation.md
@@ -40,17 +40,17 @@
 }
 
 @5
-"#123_456": text.md
+"#123_456": source.text.md
 
 @6
-"#123-456": text.md
+"#123-456": source.text.md
 
 @7
-"#123-#456": text.md
+"#123-#456": source.text.md
 
 @8
 "#123:456" {
-  text.md {
+  source.text.md {
     "#123" {
       reference.gfm.variable.md {
         "#": punctuation.md
@@ -63,7 +63,7 @@
 
 @9
 ""#123"" {
-  text.md {
+  source.text.md {
     """
     "#123" {
       reference.gfm.variable.md {
@@ -77,7 +77,7 @@
 
 @10
 "'#123'" {
-  text.md {
+  source.text.md {
     "'"
     "#123" {
       reference.gfm.variable.md {
@@ -91,7 +91,7 @@
 
 @11
 "(#123)" {
-  text.md {
+  source.text.md {
     "("
     "#123" {
       reference.gfm.variable.md {
@@ -108,7 +108,7 @@
 # mentions.
 @12
 "[#123]" {
-  text.md {
+  source.text.md {
     label.link.string.md {
       "[": punctuation.md
       "#123"
@@ -121,7 +121,7 @@
 # Technically okay, but a weird thing to do...
 @13
 "(#123]" {
-  text.md {
+  source.text.md {
     "("
     "#123" {
       reference.gfm.variable.md {
@@ -135,7 +135,7 @@
 
 @14
 ">#123" {
-  text.md {
+  source.text.md {
     quote.markup.md {
       ">": punctuation.md
       "#123" {
@@ -150,7 +150,7 @@
 
 @15
 "#123, #456, #789" {
-  text.md {
+  source.text.md {
     "#123" {
       reference.gfm.variable.md {
         "#": punctuation.md
@@ -175,11 +175,11 @@
 }
 
 @16
-"#123=done": text.md
+"#123=done": source.text.md
 
 @17
 "#123." {
-  text.md {
+  source.text.md {
     "#123" {
       reference.gfm.variable.md {
         "#": punctuation.md
@@ -191,14 +191,14 @@
 }
 
 @18
-"-#123": text.md
+"-#123": source.text.md
 
 @19
-"#-123": text.md
+"#-123": source.text.md
 
 @20
 "- #123" {
-  text.md {
+  source.text.md {
     unordered.list.markup.md {
       "- ": punctuation.md
       "#123" {
@@ -213,7 +213,7 @@
 
 # TODO
 # @21
-# "#atom/123": text.md
+# "#atom/123": source.text.md
 
 @22
-"#123-": text.md
+"#123-": source.text.md

--- a/spec/fixtures/flavors/github/mentions.ass
+++ b/spec/fixtures/flavors/github/mentions.ass
@@ -1,6 +1,6 @@
 @1
 "@username" {
-  text.md {
+  source.text.md {
     "@username" {
       reference.gfm.variable.md {
         "@": punctuation.md
@@ -12,7 +12,7 @@
 
 @2
 "@user name" {
-  text.md {
+  source.text.md {
     "@user" {
       reference.gfm.variable.md {
         "@": punctuation.md
@@ -24,11 +24,11 @@
 }
 
 @3
-"user@name": text.md
+"user@name": source.text.md
 
 @4
 "@username: something, something" {
-  text.md {
+  source.text.md {
     "@username" {
       reference.gfm.variable.md {
         "@": punctuation.md
@@ -41,7 +41,7 @@
 
 @5
 "@userName123" {
-  text.md {
+  source.text.md {
     "@userName123" {
       reference.gfm.variable.md {
         "@": punctuation.md
@@ -52,11 +52,11 @@
 }
 
 @6
-"@user_name": text.md
+"@user_name": source.text.md
 
 @7
 "@user-name" {
-  text.md {
+  source.text.md {
     "@user-name" {
       reference.gfm.variable.md {
         "@": punctuation.md
@@ -67,11 +67,11 @@
 }
 
 @8
-"@:user:name": text.md
+"@:user:name": source.text.md
 
 @9
 "@user:name" {
-  text.md {
+  source.text.md {
     "@user" {
       reference.gfm.variable.md {
         "@": punctuation.md
@@ -84,7 +84,7 @@
 
 @10
 ""@username"" {
-  text.md {
+  source.text.md {
     """
     "@username" {
       reference.gfm.variable.md {
@@ -98,7 +98,7 @@
 
 @11
 "'@username'" {
-  text.md {
+  source.text.md {
     "'"
     "@username" {
       reference.gfm.variable.md {
@@ -112,7 +112,7 @@
 
 @12
 "(@username)" {
-  text.md {
+  source.text.md {
     "("
     "@username" {
       reference.gfm.variable.md {
@@ -129,7 +129,7 @@
 # mentions.
 @13
 "[@username]" {
-  text.md {
+  source.text.md {
     label.link.string.md {
       "[": punctuation.md
       "@username"
@@ -142,7 +142,7 @@
 # technically okay, but a weird thing to do...
 @14
 "(@username]" {
-  text.md {
+  source.text.md {
     "("
     "@username" {
       reference.gfm.variable.md {
@@ -156,7 +156,7 @@
 
 @15
 ">@username" {
-  text.md {
+  source.text.md {
     quote.markup.md {
       ">": punctuation.md
       "@username" {
@@ -171,7 +171,7 @@
 
 @16
 "@one, @two, @three" {
-  text.md {
+  source.text.md {
     "@one" {
       reference.gfm.variable.md {
         "@": punctuation.md
@@ -196,11 +196,11 @@
 }
 
 @17
-"@username=cool": text.md
+"@username=cool": source.text.md
 
 @18
 "@username." {
-  text.md {
+  source.text.md {
     "@username" {
       reference.gfm.variable.md {
         "@": punctuation.md
@@ -212,11 +212,11 @@
 }
 
 @19
-"-@username": text.md
+"-@username": source.text.md
 
 @20
 "- @username" {
-  text.md {
+  source.text.md {
     unordered.list.markup.md {
       "- ": punctuation.md
       "@username" {
@@ -231,7 +231,7 @@
 
 @21
 "@atom/feedback" {
-  text.md {
+  source.text.md {
     "@atom/feedback" {
       reference.gfm.variable.md {
         "@": punctuation.md
@@ -242,4 +242,4 @@
 }
 
 @22
-"@username-": text.md
+"@username-": source.text.md

--- a/spec/fixtures/flavors/github/references.ass
+++ b/spec/fixtures/flavors/github/references.ass
@@ -1,6 +1,6 @@
 @1
 "a5c3785ed8d6a35868bc169f07e40e889087fd2e" {
-  text.md {
+  source.text.md {
     reference.gfm.variable.md {
       sha.gfm.md {
         "a5c3785"
@@ -12,7 +12,7 @@
 
 @2
 "jlord@a5c3785ed8d6a35868bc169f07e40e889087fd2e" {
-  text.md {
+  source.text.md {
     reference.gfm.variable.md {
       "jlord": user.gfm.md
       "@": punctuation.md
@@ -28,7 +28,7 @@
 
 @3
 "jlord/sheetsee.js@a5c3785ed8d6a35868bc169f07e40e889087fd2e" {
-  text.md {
+  source.text.md {
     reference.gfm.variable.md {
       "jlord": user.gfm.md
       "/": punctuation.md
@@ -46,7 +46,7 @@
 
 @4
 "GH-26" {
-  text.md {
+  source.text.md {
     reference.gfm.variable.md {
       "GH-": punctuation.md
       "26": issue.gfm.md
@@ -56,7 +56,7 @@
 
 @5
 "jlord/sheetsee.js#26" {
-  text.md {
+  source.text.md {
     reference.gfm.variable.md {
       "jlord": user.gfm.md
       "/": punctuation.md

--- a/spec/fixtures/flavors/github/strike-through.ass
+++ b/spec/fixtures/flavors/github/strike-through.ass
@@ -1,6 +1,6 @@
 @1
 "~~bad~~ word" {
-  text.md {
+  source.text.md {
     strike.markup.md {
       "~~": punctuation.md
       "bad"
@@ -11,7 +11,7 @@
 }
 
 @2
-"~~bad~~word": text.md
+"~~bad~~word": source.text.md
 
 @3
-"good~~bad~~": text.md
+"good~~bad~~": source.text.md

--- a/spec/fixtures/flavors/github/tables.ass
+++ b/spec/fixtures/flavors/github/tables.ass
@@ -1,6 +1,6 @@
 @1
 "| one | two | three |" {
-  text.md {
+  source.text.md {
     table.storage.md {
       "|": punctuation.md
       " one "
@@ -14,11 +14,11 @@
 }
 
 @2
-"one | two | three |": text.md
+"one | two | three |": source.text.md
 
 @3
 "| one | two | three" {
-  text.md {
+  source.text.md {
     table.storage.md {
       "|": punctuation.md
       " one "
@@ -31,11 +31,11 @@
 }
 
 @4
-"|one|two|three|": text.md
+"|one|two|three|": source.text.md
 
 @5
 "| --- | --- | --- |" {
-  text.md {
+  source.text.md {
     table.storage.md {
       "|": punctuation.md
       " "
@@ -55,11 +55,11 @@
 }
 
 @6
-"--- | --- | --- |": text.md
+"--- | --- | --- |": source.text.md
 
 @7
 "| --- | --- | ---" {
-  text.md {
+  source.text.md {
     table.storage.md {
       "|": punctuation.md
       " "
@@ -77,11 +77,11 @@
 }
 
 @8
-"|---|---|---|": text.md
+"|---|---|---|": source.text.md
 
 @9
 "|:--- |:---:| ---:|" {
-  text.md {
+  source.text.md {
     table.storage.md {
       "|": punctuation.md
       ":": alignment.punctuation.md
@@ -102,7 +102,7 @@
 
 @10
 "| :-- | :-: | --: |" {
-  text.md {
+  source.text.md {
     table.storage.md {
       "|": punctuation.md
       " "
@@ -127,7 +127,7 @@
 
 @11
 "| _one_ | **two** | [three] |" {
-  text.md {
+  source.text.md {
     table.storage.md {
       "|": punctuation.md
       " "
@@ -166,7 +166,7 @@
 
 @12
 "| --- | --- | three |" {
-  text.md {
+  source.text.md {
     table.storage.md {
       "|": punctuation.md
       " "

--- a/spec/fixtures/flavors/github/tables.ass
+++ b/spec/fixtures/flavors/github/tables.ass
@@ -84,17 +84,17 @@
   source.text.md {
     table.storage.md {
       "|": punctuation.md
-      ":": alignment.punctuation.md
+      ":": alignment.punctuation.meta.md
       "---": punctuation.md
       " "
       "|": punctuation.md
-      ":": alignment.punctuation.md
+      ":": alignment.punctuation.meta.md
       "---": punctuation.md
-      ":": alignment.punctuation.md
+      ":": alignment.punctuation.meta.md
       "|": punctuation.md
       " "
       "---": punctuation.md
-      ":": alignment.punctuation.md
+      ":": alignment.punctuation.meta.md
       "|": punctuation.md
     }
   }
@@ -106,19 +106,19 @@
     table.storage.md {
       "|": punctuation.md
       " "
-      ":": alignment.punctuation.md
+      ":": alignment.punctuation.meta.md
       "--": punctuation.md
       " "
       "|": punctuation.md
       " "
-      ":": alignment.punctuation.md
+      ":": alignment.punctuation.meta.md
       "-": punctuation.md
-      ":": alignment.punctuation.md
+      ":": alignment.punctuation.meta.md
       " "
       "|": punctuation.md
       " "
       "--": punctuation.md
-      ":": alignment.punctuation.md
+      ":": alignment.punctuation.meta.md
       " "
       "|": punctuation.md
     }

--- a/spec/fixtures/flavors/github/task-lists.ass
+++ b/spec/fixtures/flavors/github/task-lists.ass
@@ -1,6 +1,6 @@
 @1
 "- [ ] Task" {
-  text.md {
+  source.text.md {
     task.unordered.list.markup.md {
       "- [ ] " {
         punctuation.md {
@@ -16,7 +16,7 @@
 
 @2
 "- [x] Completed task" {
-  text.md {
+  source.text.md {
     completed.task.unordered.list.markup.md {
       "- [x] " {
         punctuation.md {
@@ -32,7 +32,7 @@
 
 @3
 "- [] Not a task" {
-  text.md {
+  source.text.md {
     unordered.list.markup.md {
       "- ": punctuation.md
       "[]" {
@@ -48,7 +48,7 @@
 
 @4
 "-[ ] Not a task" {
-  text.md {
+  source.text.md {
     "-"
     "[ ]" {
       label.link.string.md {
@@ -63,7 +63,7 @@
 
 @5
 "-[] Not a task" {
-  text.md {
+  source.text.md {
     "-"
     "[]" {
       label.link.string.md {
@@ -77,7 +77,7 @@
 
 @6
 "- [ ]Not a task" {
-  text.md {
+  source.text.md {
     unordered.list.markup.md {
       "- ": punctuation.md
       "[ ]" {
@@ -94,7 +94,7 @@
 
 @7
 "-[ ]Not a task" {
-  text.md {
+  source.text.md {
     "-"
     "[ ]" {
       label.link.string.md {
@@ -109,7 +109,7 @@
 
 @8
 "-[]Not a task" {
-  text.md {
+  source.text.md {
     "-"
     "[]" {
       label.link.string.md {
@@ -123,7 +123,7 @@
 
 @9
 "- [  ] Not a task" {
-  text.md {
+  source.text.md {
     unordered.list.markup.md {
       "- ": punctuation.md
       "[  ]" {
@@ -140,7 +140,7 @@
 
 @10
 "- [X] Not a completed task, I think" {
-  text.md {
+  source.text.md {
     unordered.list.markup.md {
       "- ": punctuation.md
       "[X]" {

--- a/spec/fixtures/flavors/markdown-extra.ass
+++ b/spec/fixtures/flavors/markdown-extra.ass
@@ -4,7 +4,7 @@
   source.text.md {
     "That's some text with a footnote."
     "[^1]" {
-      reference.footnote.link.markup.md {
+      reference.footnote.link.markup.entity.md {
         label.link.string.md {
           "[^": punctuation.md
           "1"
@@ -13,7 +13,7 @@
       }
     }
     "[^1]:" {
-      definition.footnote.link.markup.md {
+      definition.footnote.link.markup.entity.md {
         "[^1]" {
           label.link.string.md {
             "[^": punctuation.md
@@ -34,7 +34,7 @@
   source.text.md {
     "Apple"
     ":   Pomaceous fruit of plants of the genus Malus in the family Rosaceae." {
-      definition.list.markup.md {
+      definition.list.markup.entity.md {
         ":": punctuation.md
         "   Pomaceous fruit of plants of the genus Malus in the family Rosaceae."
       }
@@ -49,13 +49,13 @@
   source.text.md {
     "Orange"
     ": The fruit of an evergreen tree of the genus Citrus." {
-      definition.list.markup.md {
+      definition.list.markup.entity.md {
         ":": punctuation.md
         " The fruit of an evergreen tree of the genus Citrus."
       }
     }
     ": Optional second line of definition-list-item" {
-      definition.list.markup.md {
+      definition.list.markup.entity.md {
         ":": punctuation.md
         " Optional second line of definition-list-item"
       }
@@ -69,7 +69,7 @@
 @5
 "*[HTML]: Hyper Text Markup Language" {
   source.text.md {
-    abbreviation.reference.link.markup.md {
+    abbreviation.reference.link.markup.entity.md {
       "*[HTML]" {
         label.link.string.md {
           "*[": punctuation.md
@@ -86,7 +86,7 @@
 @6
 "*[W3C]:  World Wide Web Consortium" {
   source.text.md {
-    abbreviation.reference.link.markup.md {
+    abbreviation.reference.link.markup.entity.md {
       "*[W3C]" {
         label.link.string.md {
           "*[": punctuation.md
@@ -103,7 +103,7 @@
 @7
 "# Heading {key=value #id .class} #" {
   source.text.md {
-    heading.markup.md {
+    heading.support.markup.md {
       heading-1.md {
         '#': punctuation.md
         ' '
@@ -118,7 +118,7 @@
 @8
 "## Open heading {.class lang=fr}" {
   source.text.md {
-    heading.markup.md {
+    heading.support.markup.md {
       heading-2.md {
         '##': punctuation.md
         ' '
@@ -152,7 +152,7 @@
 @9
 "### Le Site ######{.class .shine #title lang=fr}" {
   source.text.md {
-    heading.markup.md {
+    heading.support.markup.md {
       heading-3.md {
         "###": punctuation.md
         " "
@@ -201,7 +201,7 @@
 @10
 "[label](http://www.url.com){#id .external-link target=_blank}" {
   source.text.md {
-    link.markup.md {
+    link.markup.entity.md {
       text.link.string.md {
         "[": punctuation.md
         "label"
@@ -287,12 +287,12 @@
 @12
 "[![alt](/image.jpg "title"){.class key=value}](/url "title"){.class key=value}" {
   source.text.md {
-    link.markup.md {
+    link.markup.entity.md {
       "[![alt](/image.jpg "title"){.class key=value}]" {
         text.link.string.md {
           "[": punctuation.md
           "![alt](/image.jpg "title"){.class key=value}" {
-            link.markup.md {
+            link.markup.entity.md {
               "![alt]" {
                 image.link.string.md {
                   "![": punctuation.md
@@ -307,7 +307,7 @@
                 }
                 " "
                 "title" {
-                  title.link.md {
+                  title.link.meta.md {
                     """: punctuation.md
                     "title"
                     """: punctuation.md
@@ -346,7 +346,7 @@
           "/url": uri.underline.link.md
         }
         ' '
-        title.link.md {
+        title.link.meta.md {
           '"': punctuation.md
           "title"
           '"': punctuation.md

--- a/spec/fixtures/flavors/markdown-extra.ass
+++ b/spec/fixtures/flavors/markdown-extra.ass
@@ -1,7 +1,7 @@
 @1
 "That's some text with a footnote.[^1]"+
 "[^1]: And that's the footnote." {
-  text.md {
+  source.text.md {
     "That's some text with a footnote."
     "[^1]" {
       reference.footnote.link.markup.md {
@@ -31,7 +31,7 @@
 @2
 "Apple"+
 ":   Pomaceous fruit of plants of the genus Malus in the family Rosaceae." {
-  text.md {
+  source.text.md {
     "Apple"
     ":   Pomaceous fruit of plants of the genus Malus in the family Rosaceae." {
       definition.list.markup.md {
@@ -46,7 +46,7 @@
 "Orange"+
 ": The fruit of an evergreen tree of the genus Citrus."+
 ": Optional second line of definition-list-item" {
-  text.md {
+  source.text.md {
     "Orange"
     ": The fruit of an evergreen tree of the genus Citrus." {
       definition.list.markup.md {
@@ -64,11 +64,11 @@
 }
 
 @4
-"*[NOT]:Not an abbreviation": text.md
+"*[NOT]:Not an abbreviation": source.text.md
 
 @5
 "*[HTML]: Hyper Text Markup Language" {
-  text.md {
+  source.text.md {
     abbreviation.reference.link.markup.md {
       "*[HTML]" {
         label.link.string.md {
@@ -85,7 +85,7 @@
 
 @6
 "*[W3C]:  World Wide Web Consortium" {
-  text.md {
+  source.text.md {
     abbreviation.reference.link.markup.md {
       "*[W3C]" {
         label.link.string.md {
@@ -102,7 +102,7 @@
 
 @7
 "# Heading {key=value #id .class} #" {
-  text.md {
+  source.text.md {
     heading.markup.md {
       heading-1.md {
         '#': punctuation.md
@@ -117,7 +117,7 @@
 
 @8
 "## Open heading {.class lang=fr}" {
-  text.md {
+  source.text.md {
     heading.markup.md {
       heading-2.md {
         '##': punctuation.md
@@ -151,7 +151,7 @@
 
 @9
 "### Le Site ######{.class .shine #title lang=fr}" {
-  text.md {
+  source.text.md {
     heading.markup.md {
       heading-3.md {
         "###": punctuation.md
@@ -200,7 +200,7 @@
 
 @10
 "[label](http://www.url.com){#id .external-link target=_blank}" {
-  text.md {
+  source.text.md {
     link.markup.md {
       text.link.string.md {
         "[": punctuation.md
@@ -247,7 +247,7 @@
 "~~~~~~~~~~~~~~~~~~~~~~~~~~~~ {.js #id .class key=value}"+
 "alert("Hello world");"+
 "~~~~~~~~~~~~~~~~~~~~~~~~~~~~" {
-  text.md {
+  source.text.md {
     fenced.code.md {
       "~~~~~~~~~~~~~~~~~~~~~~~~~~~~": punctuation.md
       " "
@@ -286,7 +286,7 @@
 
 @12
 "[![alt](/image.jpg "title"){.class key=value}](/url "title"){.class key=value}" {
-  text.md {
+  source.text.md {
     link.markup.md {
       "[![alt](/image.jpg "title"){.class key=value}]" {
         text.link.string.md {

--- a/spec/fixtures/flavors/yaml-front-matter.ass
+++ b/spec/fixtures/flavors/yaml-front-matter.ass
@@ -4,7 +4,7 @@
 "- type: main"+
 "  text: My Book"+
 "..." {
-  text.md {
+  source.text.md {
     front-matter.yaml.source.md {
       "---": hr.md
       "title:"
@@ -22,7 +22,7 @@
 "- type: main"+
 "  text: My Book"+
 "..." {
-  text.md {
+  source.text.md {
     " "
     "---": hr.md
     "title:"
@@ -43,7 +43,7 @@
 "---"+
 ""+
 "This is a paragraph" {
-  text.md {
+  source.text.md {
     front-matter.yaml.source.md {
       "---": hr.md
       "front: matter"

--- a/spec/fixtures/flavors/yaml-front-matter.ass
+++ b/spec/fixtures/flavors/yaml-front-matter.ass
@@ -6,11 +6,11 @@
 "..." {
   source.text.md {
     front-matter.yaml.source.md {
-      "---": hr.md
+      "---": hr.constant.markup.md
       "title:"
       "- type: main"
       "  text: My Book"
-      "...": hr.md
+      "...": hr.constant.markup.md
     }
   }
 }
@@ -24,7 +24,7 @@
 "..." {
   source.text.md {
     " "
-    "---": hr.md
+    "---": hr.constant.markup.md
     "title:"
     "- type: main" {
       unordered.list.markup.md {
@@ -45,9 +45,9 @@
 "This is a paragraph" {
   source.text.md {
     front-matter.yaml.source.md {
-      "---": hr.md
+      "---": hr.constant.markup.md
       "front: matter"
-      "---": hr.md
+      "---": hr.constant.markup.md
     }
     ""
     "This is a paragraph"

--- a/spec/fixtures/inlines/autolinks.ass
+++ b/spec/fixtures/inlines/autolinks.ass
@@ -2,7 +2,7 @@
 
 @543
 "<http://foo.bar.baz>" {
-  text.md {
+  source.text.md {
     auto.link.markup.md {
       "<": punctuation.md
       uri.underline.markup.md {
@@ -16,7 +16,7 @@
 
 @544
 "<http://foo.bar.baz/test?q=hello&id=22&boolean>" {
-  text.md {
+  source.text.md {
     auto.link.markup.md {
       "<": punctuation.md
       uri.underline.markup.md {
@@ -30,7 +30,7 @@
 
 @545
 "<irc://foo.bar:2233/baz>" {
-  text.md {
+  source.text.md {
     auto.link.markup.md {
       "<": punctuation.md
       uri.underline.markup.md {
@@ -44,7 +44,7 @@
 
 @546
 "<MAILTO:FOO@BAR.BAZ>" {
-  text.md {
+  source.text.md {
     auto.link.markup.md {
       "<": punctuation.md
       uri.underline.markup.md {
@@ -57,11 +57,11 @@
 }
 
 @547
-"<http://foo.bar/baz bim>": text.md
+"<http://foo.bar/baz bim>": source.text.md
 
 @548
 "<http://example.com/\[\>" {
-  text.md {
+  source.text.md {
     auto.link.markup.md {
       "<": punctuation.md
       uri.underline.markup.md {
@@ -75,7 +75,7 @@
 
 @549
 "<foo@bar.example.com>" {
-  text.md {
+  source.text.md {
     email.auto.link.markup.md {
       "<": punctuation.md
       uri.underline.markup.md {
@@ -90,7 +90,7 @@
 
 @550
 "<foo+special@Bar.baz-bar0.com>" {
-  text.md {
+  source.text.md {
     email.auto.link.markup.md {
       "<": punctuation.md
       uri.underline.markup.md {
@@ -105,7 +105,7 @@
 
 @551
 "<foo\+@bar.example.com>" {
-  text.md {
+  source.text.md {
     "<foo"
     "\+": escape.constant.md
     "@bar.example.com>"
@@ -113,22 +113,22 @@
 }
 
 @552
-"<>": text.md
+"<>": source.text.md
 
 @553
-"<heck://bing.bong>": text.md
+"<heck://bing.bong>": source.text.md
 
 @554
-"< http://foo.bar >": text.md
+"< http://foo.bar >": source.text.md
 
 @555
-"<foo.bar.baz>": text.md
+"<foo.bar.baz>": source.text.md
 
 @556
-"<localhost:5001/foo>": text.md
+"<localhost:5001/foo>": source.text.md
 
 @557
-"http://example.com": text.md
+"http://example.com": source.text.md
 
 @558
-"foo@bar.example.com": text.md
+"foo@bar.example.com": source.text.md

--- a/spec/fixtures/inlines/autolinks.ass
+++ b/spec/fixtures/inlines/autolinks.ass
@@ -3,7 +3,7 @@
 @543
 "<http://foo.bar.baz>" {
   source.text.md {
-    auto.link.markup.md {
+    auto.link.markup.entity.md {
       "<": punctuation.md
       uri.underline.markup.md {
         "http": scheme.md
@@ -17,7 +17,7 @@
 @544
 "<http://foo.bar.baz/test?q=hello&id=22&boolean>" {
   source.text.md {
-    auto.link.markup.md {
+    auto.link.markup.entity.md {
       "<": punctuation.md
       uri.underline.markup.md {
         "http": scheme.md
@@ -31,7 +31,7 @@
 @545
 "<irc://foo.bar:2233/baz>" {
   source.text.md {
-    auto.link.markup.md {
+    auto.link.markup.entity.md {
       "<": punctuation.md
       uri.underline.markup.md {
         "irc": scheme.md
@@ -45,7 +45,7 @@
 @546
 "<MAILTO:FOO@BAR.BAZ>" {
   source.text.md {
-    auto.link.markup.md {
+    auto.link.markup.entity.md {
       "<": punctuation.md
       uri.underline.markup.md {
         "MAILTO": scheme.md
@@ -62,7 +62,7 @@
 @548
 "<http://example.com/\[\>" {
   source.text.md {
-    auto.link.markup.md {
+    auto.link.markup.entity.md {
       "<": punctuation.md
       uri.underline.markup.md {
         "http": scheme.md
@@ -76,7 +76,7 @@
 @549
 "<foo@bar.example.com>" {
   source.text.md {
-    email.auto.link.markup.md {
+    email.auto.link.markup.entity.md {
       "<": punctuation.md
       uri.underline.markup.md {
         "foo"
@@ -91,7 +91,7 @@
 @550
 "<foo+special@Bar.baz-bar0.com>" {
   source.text.md {
-    email.auto.link.markup.md {
+    email.auto.link.markup.entity.md {
       "<": punctuation.md
       uri.underline.markup.md {
         "foo+special"

--- a/spec/fixtures/inlines/code-spans.ass
+++ b/spec/fixtures/inlines/code-spans.ass
@@ -1,7 +1,7 @@
 # http://spec.commonmark.org/0.22/#example-298
 @298a
 "`foo`" {
-  text.md {
+  source.text.md {
     code.raw.markup.md {
       '`': punctuation.md
       'foo'
@@ -12,7 +12,7 @@
 
 @298b
 "before`foo`after" {
-  text.md {
+  source.text.md {
     "before"
     code.raw.markup.md {
       '`': punctuation.md
@@ -25,7 +25,7 @@
 
 @298c
 "before `foo` after" {
-  text.md {
+  source.text.md {
     "before "
     code.raw.markup.md {
       '`': punctuation.md
@@ -39,7 +39,7 @@
 # http://spec.commonmark.org/0.22/#example-299
 @299
 "`` foo ` bar  ``" {
-  text.md {
+  source.text.md {
     code.raw.markup.md {
       '``': punctuation.md
       ' foo ` bar  '
@@ -51,7 +51,7 @@
 # http://spec.commonmark.org/0.22/#example-300
 @300
 "` `` `" {
-  text.md {
+  source.text.md {
     code.raw.markup.md {
       '`': punctuation.md
       ' `` '
@@ -65,7 +65,7 @@
 "``"+
 "foo"+
 "``" {
-  text.md {
+  source.text.md {
     '``'
     'foo'
     '``'
@@ -76,7 +76,7 @@
 @302
 "`foo   bar"+
 "  baz`" {
-  text.md {
+  source.text.md {
     '`foo   bar'
     '  baz`'
   }
@@ -85,7 +85,7 @@
 # http://spec.commonmark.org/0.22/#example-303
 @303
 "`foo `` bar`" {
-  text.md {
+  source.text.md {
     code.raw.markup.md {
       '`': punctuation.md
       'foo `` bar'
@@ -97,7 +97,7 @@
 # http://spec.commonmark.org/0.22/#example-304
 @304
 "`foo\`bar`" {
-  text.md {
+  source.text.md {
     code.raw.markup.md {
       '`': punctuation.md
       'foo\'
@@ -111,7 +111,7 @@
 # @305
 # http://spec.commonmark.org/0.22/#example-305
 # "*foo`*`" {
-#   text.md {
+#   source.text.md {
 #     '*foo'
 #     code.raw.markup.md {
 #       '`': punctuation.md
@@ -125,7 +125,7 @@
 # http://spec.commonmark.org/0.22/#example-306
 # @306
 # "[not a `link](/foo`)" {
-#   text.md {
+#   source.text.md {
 #     '[not a'
 #     code.raw.markup.md {
 #       '`': punctuation.md
@@ -139,7 +139,7 @@
 # http://spec.commonmark.org/0.22/#example-307
 @307
 "`<a href="`">`" {
-  text.md {
+  source.text.md {
     code.raw.markup.md {
       '`': punctuation.md
       '<a href="'
@@ -153,7 +153,7 @@
 # test fails, because the html package is not included when testing, but it does work in an actual document
 # @308
 # '<a href="`">`' {
-#   text.md {
+#   source.text.md {
 #     meta.tag.inline.any.html {
 #       "<": punctuation.definition.tag.begin.html
 #       "a": entity.name.tag.inline.any.html
@@ -174,7 +174,7 @@
 # http://spec.commonmark.org/0.22/#example-309
 @309
 "`<http://foo.bar.`baz>`" {
-  text.md {
+  source.text.md {
     code.raw.markup.md {
       '`': punctuation.md
       '<http://foo.bar.'
@@ -193,8 +193,8 @@
 
 # http://spec.commonmark.org/0.22/#example-311
 @311
-'```foo``': text.md
+'```foo``': source.text.md
 
 # http://spec.commonmark.org/0.22/#example-312
 @312
-'`foo': text.md
+'`foo': source.text.md

--- a/spec/fixtures/inlines/emphasis.ass
+++ b/spec/fixtures/inlines/emphasis.ass
@@ -441,7 +441,7 @@
     emphasis.italic.markup.md {
       "*": punctuation.md
       'foo '
-      link.markup.md {
+      link.markup.entity.md {
         text.link.string.md {
           "[": punctuation.md
           "bar"
@@ -692,7 +692,7 @@
     strong.emphasis.bold.markup.md {
       "**": punctuation.md
       'foo '
-      link.markup.md {
+      link.markup.entity.md {
         text.link.string.md {
           "[": punctuation.md
           "bar"
@@ -891,7 +891,7 @@
     strong.emphasis.bold.markup.md {
       "**": punctuation.md
       'foo '
-      link.markup.md {
+      link.markup.entity.md {
         text.link.string.md {
           "[": punctuation.md
           emphasis.italic.markup.md {

--- a/spec/fixtures/inlines/emphasis.ass
+++ b/spec/fixtures/inlines/emphasis.ass
@@ -2,7 +2,7 @@
 
 @313
 "*foo bar*" {
-  text.md {
+  source.text.md {
     emphasis.italic.markup.md {
       "*": punctuation.md
       "foo bar"
@@ -12,10 +12,10 @@
 }
 
 @314
-"a * foo bar*": text.md
+"a * foo bar*": source.text.md
 
 @315
-"a*"foo"*": text.md
+"a*"foo"*": source.text.md
 
 # NOTE
 # The first space character is a non-breaking space, and as such this should
@@ -25,11 +25,11 @@
 # worked ;) @burodepeper
 #
 # @316
-# "* a *": text.md
+# "* a *": source.text.md
 
 @317
 "foo*bar*" {
-  text.md {
+  source.text.md {
     "foo"
     emphasis.italic.markup.md {
       "*": punctuation.md
@@ -41,7 +41,7 @@
 
 @318
 "5*6*78" {
-  text.md {
+  source.text.md {
     "5"
     emphasis.italic.markup.md {
       "*": punctuation.md
@@ -54,7 +54,7 @@
 
 @319
 "_foo bar_" {
-  text.md {
+  source.text.md {
     emphasis.italic.markup.md {
       "_": punctuation.md
       "foo bar"
@@ -64,26 +64,26 @@
 }
 
 @320
-"_ foo bar_": text.md
+"_ foo bar_": source.text.md
 
 @321
-"a_"foo"_": text.md
+"a_"foo"_": source.text.md
 
 @322
-"foo_bar_": text.md
+"foo_bar_": source.text.md
 
 @323
-"5_6_78": text.md
+"5_6_78": source.text.md
 
 @324
-"пристаням_стремятся_": text.md
+"пристаням_стремятся_": source.text.md
 
 @325
-"aa_"bb"_cc": text.md
+"aa_"bb"_cc": source.text.md
 
 @326
 "foo-_(bar)_" {
-  text.md {
+  source.text.md {
     "foo-"
     emphasis.italic.markup.md {
       "_": punctuation.md
@@ -94,14 +94,14 @@
 }
 
 @327
-"_foo*": text.md
+"_foo*": source.text.md
 
 @328
-"*foo bar *": text.md
+"*foo bar *": source.text.md
 
 @329
 "*foo bar\n*" {
-  text.md {
+  source.text.md {
     "*foo bar"
     empty.unordered.list.markup.md {
       "*": punctuation.md
@@ -110,12 +110,12 @@
 }
 
 @330
-"*(*foo)": text.md
+"*(*foo)": source.text.md
 
 # FIXME
 # @331
 # "*(*foo*)*" {
-#   text.md {
+#   source.text.md {
 #     emphasis.italic.markup.md {
 #       "*": punctuation.md
 #       "("
@@ -135,15 +135,15 @@
 # @burodepeper
 
 @333
-"_foo bar _": text.md
+"_foo bar _": source.text.md
 
 @334
-"_(_foo)": text.md
+"_(_foo)": source.text.md
 
 # FIXME
 # @335
 # "_(_foo_)_" {
-#   text.md {
+#   source.text.md {
 #     emphasis.italic.markup.md {
 #       "_": punctuation.md
 #       "("
@@ -159,14 +159,14 @@
 # }
 
 @336
-"_foo_bar": text.md
+"_foo_bar": source.text.md
 
 @337
-"_пристаням_стремятся": text.md
+"_пристаням_стремятся": source.text.md
 
 @338
 "_foo_bar_baz_" {
-  text.md {
+  source.text.md {
     emphasis.italic.markup.md {
       "_": punctuation.md
       "foo_bar_baz"
@@ -177,7 +177,7 @@
 
 @339
 "_(bar)_." {
-  text.md {
+  source.text.md {
     emphasis.italic.markup.md {
       "_": punctuation.md
       "(bar)"
@@ -189,7 +189,7 @@
 
 @340
 "**foo bar**" {
-  text.md {
+  source.text.md {
     strong.emphasis.bold.markup.md {
       "**": punctuation.md
       "foo bar"
@@ -199,14 +199,14 @@
 }
 
 @341
-"** foo bar**": text.md
+"** foo bar**": source.text.md
 
 @342
-"a**"foo"**": text.md
+"a**"foo"**": source.text.md
 
 @343
 "foo**bar**" {
-  text.md {
+  source.text.md {
     "foo"
     strong.emphasis.bold.markup.md {
       "**": punctuation.md
@@ -218,7 +218,7 @@
 
 @344
 "__foo bar__" {
-  text.md {
+  source.text.md {
     strong.emphasis.bold.markup.md {
       "__": punctuation.md
       "foo bar"
@@ -228,32 +228,32 @@
 }
 
 @345
-"__ foo bar__": text.md
+"__ foo bar__": source.text.md
 
 @346
 "__\nfoo bar__" {
-  text.md {
+  source.text.md {
     "__"
     "foo bar__"
   }
 }
 
 @347
-"a__"foo"__": text.md
+"a__"foo"__": source.text.md
 
 @348
-"foo__bar__": text.md
+"foo__bar__": source.text.md
 
 @349
-"5__6__78": text.md
+"5__6__78": source.text.md
 
 @350
-"пристаням__стремятся__": text.md
+"пристаням__стремятся__": source.text.md
 
 # FIXME
 # @351
 # "__foo, __bar__, baz__" {
-#   text.md {
+#   source.text.md {
 #     strong.emphasis.bold.markup.md {
 #       "__": punctuation.md
 #       "foo, "
@@ -270,7 +270,7 @@
 
 @352
 "foo-__(bar)__" {
-  text.md {
+  source.text.md {
     "foo-"
     strong.emphasis.bold.markup.md {
       "__": punctuation.md
@@ -281,15 +281,15 @@
 }
 
 @353
-"**foo bar **": text.md
+"**foo bar **": source.text.md
 
 @354
-"**(**foo)": text.md
+"**(**foo)": source.text.md
 
 # FIXME
 # @355
 # "*(**foo**)*" {
-#   text.md {
+#   source.text.md {
 #     emphasis.italic.markup.md {
 #       "*": punctuation.md
 #       "("
@@ -308,7 +308,7 @@
 # @356a
 # "**Gomphocarpus (*Gomphocarpus physocarpus*, syn."+
 # "*Asclepias physocarpa*)**" {
-#   text.md {
+#   source.text.md {
 #     strong.emphasis.bold.markup.md {
 #       "**": punctuation.md
 #       "Gomphocarpus ("
@@ -331,7 +331,7 @@
 
 @356b
 "**Gomphocarpus (*Gomphocarpus physocarpus*, syn. *Asclepias physocarpa*)**" {
-  text.md {
+  source.text.md {
     strong.emphasis.bold.markup.md {
       "**": punctuation.md
       "Gomphocarpus ("
@@ -354,7 +354,7 @@
 
 @357
 "**foo "*bar*" foo**" {
-  text.md {
+  source.text.md {
     strong.emphasis.bold.markup.md {
       "**": punctuation.md
       'foo "'
@@ -371,7 +371,7 @@
 
 @358
 "**foo**bar" {
-  text.md {
+  source.text.md {
     strong.emphasis.bold.markup.md {
       "**": punctuation.md
       'foo'
@@ -382,15 +382,15 @@
 }
 
 @359
-"__foo bar __": text.md
+"__foo bar __": source.text.md
 
 @360
-"__(__foo)": text.md
+"__(__foo)": source.text.md
 
 # FIXME
 # @361
 # "_(__foo__)_" {
-#   text.md {
+#   source.text.md {
 #     emphasis.italic.markup.md {
 #       "_": punctuation.md
 #       '('
@@ -406,15 +406,15 @@
 # }
 
 @362
-"__foo__bar": text.md
+"__foo__bar": source.text.md
 
 @363
-"__пристаням__стремятся": text.md
+"__пристаням__стремятся": source.text.md
 
 # FIXME
 # @364
 # "__foo__bar__baz__" {
-#   text.md {
+#   source.text.md {
 #     strong.emphasis.bold.markup.md {
 #       "__": punctuation.md
 #       'foo__bar_baz'
@@ -425,7 +425,7 @@
 
 @365
 "__(bar)__." {
-  text.md {
+  source.text.md {
     strong.emphasis.bold.markup.md {
       "__": punctuation.md
       '(bar)'
@@ -437,7 +437,7 @@
 
 @366
 "*foo [bar](/url)*" {
-  text.md {
+  source.text.md {
     emphasis.italic.markup.md {
       "*": punctuation.md
       'foo '
@@ -461,7 +461,7 @@
 # TODO multiline
 # @367
 # "*foo\nbar*" {
-#   text.md {
+#   source.text.md {
 #     emphasis.italic.markup.md {
 #       "*": punctuation.md
 #       'foo'
@@ -475,7 +475,7 @@
 # FIXME
 # @368
 # "_foo __bar__ baz_" {
-#   text.md {
+#   source.text.md {
 #     emphasis.italic.markup.md {
 #       '_': punctuation.md
 #       'foo '
@@ -493,7 +493,7 @@
 # FIXME
 # @369
 # "_foo _bar_ baz_" {
-#   text.md {
+#   source.text.md {
 #     emphasis.italic.markup.md {
 #       '_': punctuation.md
 #       'foo '
@@ -511,7 +511,7 @@
 # FIXME
 # @370
 # "__foo_ bar_" {
-#   text.md {
+#   source.text.md {
 #     emphasis.italic.markup.md {
 #       '_': punctuation.md
 #       emphasis.italic.markup.md {
@@ -528,7 +528,7 @@
 # FIXME
 # @371
 # "*foo *bar**" {
-#   text.md {
+#   source.text.md {
 #     emphasis.italic.markup.md {
 #       '*': punctuation.md
 #       'foo '
@@ -545,7 +545,7 @@
 # FIXME
 # @372
 # "*foo **bar** baz*" {
-#   text.md {
+#   source.text.md {
 #     emphasis.italic.markup.md {
 #       '*': punctuation.md
 #       'foo '
@@ -563,7 +563,7 @@
 # FIXME
 # @373
 # "*foo**bar**baz*" {
-#   text.md {
+#   source.text.md {
 #     emphasis.italic.markup.md {
 #       '*': punctuation.md
 #       'foo'
@@ -581,7 +581,7 @@
 # FIXME
 # @374
 # "***foo** bar*" {
-#   text.md {
+#   source.text.md {
 #     emphasis.italic.markup.md {
 #       "*": punctuation.md
 #       strong.emphasis.bold.markup.md {
@@ -598,7 +598,7 @@
 # FIXME
 # @375
 # "*foo **bar***" {
-#   text.md {
+#   source.text.md {
 #     emphasis.italic.markup.md {
 #       "*": punctuation.md
 #       "foo "
@@ -615,7 +615,7 @@
 # FIXME
 # @376
 # "*foo**bar***" {
-#   text.md {
+#   source.text.md {
 #     emphasis.italic.markup.md {
 #       "*": punctuation.md
 #       "foo"
@@ -631,7 +631,7 @@
 # FIXME
 # @377
 # "*foo **bar *baz* bim** bop*" {
-#   text.md {
+#   source.text.md {
 #     emphasis.italic.markup.md {
 #       "*": punctuation.md
 #       "foo "
@@ -655,7 +655,7 @@
 # FIXME
 # @378
 # "*foo [*bar*](/url)*" {
-#   text.md {
+#   source.text.md {
 #     emphasis.italic.markup.md {
 #       "*": punctuation.md
 #       'foo '
@@ -681,14 +681,14 @@
 # }
 
 @379
-"** is not an empty emphasis": text.md
+"** is not an empty emphasis": source.text.md
 
 @380
-"**** is not an empty strong emphasis": text.md
+"**** is not an empty strong emphasis": source.text.md
 
 @381
 "**foo [bar](/url)**" {
-  text.md {
+  source.text.md {
     strong.emphasis.bold.markup.md {
       "**": punctuation.md
       'foo '
@@ -712,7 +712,7 @@
 # FIXME multiline
 # @382
 # "**foo\nbar**" {
-#   text.md {
+#   source.text.md {
 #     strong.emphasis.bold.markup.md {
 #       "**": punctuation.md
 #       'foo'
@@ -724,7 +724,7 @@
 
 @383
 "__foo _bar_ baz__" {
-  text.md {
+  source.text.md {
     strong.emphasis.bold.markup.md {
       "__": punctuation.md
       'foo '
@@ -742,7 +742,7 @@
 # FIXME
 # @384
 # "__foo __bar__ baz__" {
-#   text.md {
+#   source.text.md {
 #     strong.emphasis.bold.markup.md {
 #       "__": punctuation.md
 #       'foo '
@@ -760,7 +760,7 @@
 # FIXME
 # @385
 # "____foo__ bar__" {
-#   text.md {
+#   source.text.md {
 #     strong.emphasis.bold.markup.md {
 #       "__": punctuation.md
 #       strong.emphasis.bold.markup.md {
@@ -777,7 +777,7 @@
 # FIXME
 # @386
 # "**foo **bar****" {
-#   text.md {
+#   source.text.md {
 #     strong.emphasis.bold.markup.md {
 #       "**": punctuation.md
 #       "foo "
@@ -793,7 +793,7 @@
 
 @387
 "**foo *bar* baz**" {
-  text.md {
+  source.text.md {
     strong.emphasis.bold.markup.md {
       "**": punctuation.md
       "foo "
@@ -812,7 +812,7 @@
 # FIXME
 # @388
 # "**foo*bar*baz**" {
-#   text.md {
+#   source.text.md {
 #     emphasis.italic.markup.md {
 #       "*": punctuation.md
 #       emphasis.italic.markup.md {
@@ -829,7 +829,7 @@
 
 @389
 "***foo* bar**" {
-  text.md {
+  source.text.md {
     strong.emphasis.bold.markup.md {
       "**": punctuation.md
       emphasis.italic.markup.md {
@@ -846,7 +846,7 @@
 # FIXME
 # @390
 # "**foo *bar***" {
-#   text.md {
+#   source.text.md {
 #     strong.emphasis.bold.markup.md {
 #       "**": punctuation.md
 #       "foo "
@@ -864,7 +864,7 @@
 # @391
 # "**foo *bar **baz**"+
 # "bim* bop**" {
-#   text.md {
+#   source.text.md {
 #     strong.emphasis.bold.markup.md {
 #       "**": punctuation.md
 #       "foo "
@@ -887,7 +887,7 @@
 
 @392
 "**foo [*bar*](/url)**" {
-  text.md {
+  source.text.md {
     strong.emphasis.bold.markup.md {
       "**": punctuation.md
       'foo '
@@ -913,17 +913,17 @@
 }
 
 @393
-"__ is not an empty emphasis": text.md
+"__ is not an empty emphasis": source.text.md
 
 @394
-"____ is not an empty strong emphasis": text.md
+"____ is not an empty strong emphasis": source.text.md
 
 @395
-"foo ***": text.md
+"foo ***": source.text.md
 
 @396
 "foo *\**" {
-  text.md {
+  source.text.md {
     "foo "
     emphasis.italic.markup.md {
       "*": punctuation.md
@@ -935,7 +935,7 @@
 
 @397
 "foo *_*" {
-  text.md {
+  source.text.md {
     "foo "
     emphasis.italic.markup.md {
       "*": punctuation.md
@@ -948,12 +948,12 @@
 # FIXME
 # @398
 # "foo *****" {
-#   "foo *****": text.md
+#   "foo *****": source.text.md
 # }
 
 @399
 "foo **\***" {
-  text.md {
+  source.text.md {
     "foo "
     strong.emphasis.bold.markup.md {
       "**": punctuation.md
@@ -965,7 +965,7 @@
 
 @400
 "foo **_**" {
-  text.md {
+  source.text.md {
     "foo "
     strong.emphasis.bold.markup.md {
       "**": punctuation.md
@@ -978,7 +978,7 @@
 # FIXME
 # @401
 # "**foo*" {
-#   text.md {
+#   source.text.md {
 #     "*"
 #     emphasis.italic.markup.md {
 #       "*": punctuation.md
@@ -990,7 +990,7 @@
 
 @402
 "*foo**" {
-  text.md {
+  source.text.md {
     emphasis.italic.markup.md {
       "*": punctuation.md
       "foo"
@@ -1003,7 +1003,7 @@
 # FIXME
 # @403
 # "***foo**" {
-#   text.md {
+#   source.text.md {
 #     "*"
 #     strong.emphasis.bold.markup.md {
 #       "**": punctuation.md
@@ -1016,7 +1016,7 @@
 # FIXME
 # @404
 # "****foo*" {
-#   text.md {
+#   source.text.md {
 #     "***"
 #     emphasis.italic.markup.md {
 #       "*": punctuation.md
@@ -1028,7 +1028,7 @@
 
 @405
 "**foo***" {
-  text.md {
+  source.text.md {
     strong.emphasis.bold.markup.md {
       "**": punctuation.md
       "foo"
@@ -1040,7 +1040,7 @@
 
 @406
 "*foo****" {
-  text.md {
+  source.text.md {
     emphasis.italic.markup.md {
       "*": punctuation.md
       "foo"
@@ -1052,12 +1052,12 @@
 
 @407
 "foo ___" {
-  "foo ___": text.md
+  "foo ___": source.text.md
 }
 
 @408
 "foo _\__" {
-  text.md {
+  source.text.md {
     "foo "
     emphasis.italic.markup.md {
       "_": punctuation.md
@@ -1069,7 +1069,7 @@
 
 @409
 "foo _*_" {
-  text.md {
+  source.text.md {
     "foo "
     emphasis.italic.markup.md {
       "_": punctuation.md
@@ -1082,12 +1082,12 @@
 # FIXME
 # @410
 # "foo _____" {
-#   "foo _____": text.md
+#   "foo _____": source.text.md
 # }
 
 @411
 "foo __\___" {
-  text.md {
+  source.text.md {
     "foo "
     strong.emphasis.bold.markup.md {
       "__": punctuation.md
@@ -1099,7 +1099,7 @@
 
 @412
 "foo __*__" {
-  text.md {
+  source.text.md {
     "foo "
     strong.emphasis.bold.markup.md {
       "__": punctuation.md
@@ -1112,7 +1112,7 @@
 # FIXME
 # @413
 # "__foo_" {
-#   text.md {
+#   source.text.md {
 #     "_"
 #     emphasis.italic.markup.md {
 #       "_": punctuation.md
@@ -1125,7 +1125,7 @@
 # FIXME
 # @414
 # "_foo__" {
-#   text.md {
+#   source.text.md {
 #     emphasis.italic.markup.md {
 #       "_": punctuation.md
 #       "foo"
@@ -1138,7 +1138,7 @@
 # FIXME
 # @415
 # "___foo__" {
-#   text.md {
+#   source.text.md {
 #     "_"
 #     strong.emphasis.bold.markup.md {
 #       "__": punctuation.md
@@ -1151,7 +1151,7 @@
 # FIXME
 # @416
 # "____foo_" {
-#   text.md {
+#   source.text.md {
 #     "___"
 #     emphasis.italic.markup.md {
 #       "_": punctuation.md
@@ -1164,7 +1164,7 @@
 # FIXME
 # @417
 # "__foo___" {
-#   text.md {
+#   source.text.md {
 #     strong.emphasis.bold.markup.md {
 #       "__": punctuation.md
 #       "foo"
@@ -1177,7 +1177,7 @@
 # FIXME
 # @418
 # "_foo____" {
-#   text.md {
+#   source.text.md {
 #     emphasis.italic.markup.md {
 #       "_": punctuation.md
 #       "foo"
@@ -1189,7 +1189,7 @@
 
 @419
 "**foo**" {
-  text.md {
+  source.text.md {
     strong.emphasis.bold.markup.md {
       "**": punctuation.md
       "foo"
@@ -1200,7 +1200,7 @@
 
 @420
 "*_foo_*" {
-  text.md {
+  source.text.md {
     emphasis.italic.markup.md {
       "*": punctuation.md
       emphasis.italic.markup.md {
@@ -1215,7 +1215,7 @@
 
 @421
 "__foo__" {
-  text.md {
+  source.text.md {
     strong.emphasis.bold.markup.md {
       "__": punctuation.md
       "foo"
@@ -1226,7 +1226,7 @@
 
 @422
 "_*foo*_" {
-  text.md {
+  source.text.md {
     emphasis.italic.markup.md {
       "_": punctuation.md
       emphasis.italic.markup.md {
@@ -1242,7 +1242,7 @@
 # FIXME
 # @423
 # "****foo****" {
-#   text.md {
+#   source.text.md {
 #     strong.emphasis.bold.markup.md {
 #       "**": punctuation.md
 #       strong.emphasis.bold.markup.md {
@@ -1257,7 +1257,7 @@
 
 @424
 "____foo____" {
-  text.md {
+  source.text.md {
     strong.emphasis.bold.markup.md {
       "__": punctuation.md
       strong.emphasis.bold.markup.md {
@@ -1273,7 +1273,7 @@
 # FIXME
 # @425
 # "******foo******" {
-#   text.md {
+#   source.text.md {
 #     strong.emphasis.bold.markup.md {
 #       "**": punctuation.md
 #       strong.emphasis.bold.markup.md {
@@ -1293,7 +1293,7 @@
 # FIXME
 # @426
 # "***foo***" {
-#   text.md {
+#   source.text.md {
 #     strong.emphasis.bold.markup.md {
 #       "**": punctuation.md
 #       emphasis.italic.markup.md {
@@ -1308,7 +1308,7 @@
 
 @427
 "_____foo_____" {
-  text.md {
+  source.text.md {
     strong.emphasis.bold.markup.md {
       "__": punctuation.md
       strong.emphasis.bold.markup.md {
@@ -1327,7 +1327,7 @@
 
 @428
 "*foo _bar* baz_" {
-  text.md {
+  source.text.md {
     emphasis.italic.markup.md {
       "*": punctuation.md
       "foo _bar"
@@ -1340,7 +1340,7 @@
 # FIXME
 # @429
 # "**foo*bar**" {
-#   text.md {
+#   source.text.md {
 #     emphasis.italic.markup.md {
 #       "*": punctuation.md
 #       emphasis.italic.markup.md {
@@ -1356,7 +1356,7 @@
 
 @430
 "*foo __bar *baz bim__ bam*" {
-  text.md {
+  source.text.md {
     emphasis.italic.markup.md {
       "*": punctuation.md
       "foo "
@@ -1374,7 +1374,7 @@
 # FIXME
 # @431
 # "**foo **bar baz**" {
-#   text.md {
+#   source.text.md {
 #     "**foo "
 #     strong.emphasis.bold.markup.md {
 #       "**": punctuation.md
@@ -1387,7 +1387,7 @@
 # FIXME
 # @432
 # "*foo *bar baz*" {
-#   text.md {
+#   source.text.md {
 #     "*foo "
 #     emphasis.italic.markup.md {
 #       "*": punctuation.md
@@ -1400,7 +1400,7 @@
 # FIXME
 # @433
 # "*[bar*](/url)" {
-#   text.md {
+#   source.text.md {
 #     "*"
 #     link.md {
 #       text.link.string.md {
@@ -1418,7 +1418,7 @@
 # FIXME
 # @434
 # "_foo [bar_](/url)" {
-#   text.md {
+#   source.text.md {
 #     "_foo "
 #     link.md {
 #       text.link.string.md {
@@ -1454,7 +1454,7 @@
 # FIXME
 # @438
 # "*a `*`*" {
-#   text.md {
+#   source.text.md {
 #     emphasis.italic.markup.md {
 #       "*": punctuation.md
 #       "a "
@@ -1471,7 +1471,7 @@
 # FIXME
 # @439
 # "_a `_`_" {
-#   text.md {
+#   source.text.md {
 #     emphasis.italic.markup.md {
 #       "_": punctuation.md
 #       "a "

--- a/spec/fixtures/inlines/entities.ass
+++ b/spec/fixtures/inlines/entities.ass
@@ -4,7 +4,7 @@
 "&nbsp; &amp; &copy; &AElig; &Dcaron;"+
 "&frac34; &HilbertSpace; &DifferentialD;"+
 "&ClockwiseContourIntegral; &ngE;" {
-  text.md {
+  source.text.md {
     entity.constant.md {
       "&": punctuation.md
       "nbsp"
@@ -67,7 +67,7 @@
 
 @287
 "&#35; &#1234; &#992; &#98765432; &#0;" {
-  text.md {
+  source.text.md {
     entity.constant.md {
       "&#": punctuation.md
       "35"
@@ -102,7 +102,7 @@
 
 @288
 "&#X22; &#XD06; &#xcab;" {
-  text.md {
+  source.text.md {
     entity.constant.md {
       "&#X": punctuation.md
       "22"
@@ -124,15 +124,15 @@
 }
 
 @289
-"&nbsp &x; &#; &#x; &ThisIsWayTooLongToBeAnEntityIsntIt; &hi?;": text.md
+"&nbsp &x; &#; &#x; &ThisIsWayTooLongToBeAnEntityIsntIt; &hi?;": source.text.md
 
 @290
-"&copy": text.md
+"&copy": source.text.md
 
 # FIXME
 # @291
 # "&MadeUpEntity;" {
-#   "&MadeUpEntity;": text.md
+#   "&MadeUpEntity;": source.text.md
 # }
 
 # TODO
@@ -165,7 +165,7 @@
 
 @296
 "`f&ouml;&ouml;`" {
-  text.md {
+  source.text.md {
     code.raw.markup.md {
       '`': punctuation.md
       "f&ouml;&ouml;"
@@ -176,7 +176,7 @@
 
 @297
 "    f&ouml;f&ouml;" {
-  text.md {
+  source.text.md {
     "    f"
     entity.constant.md {
       "&": punctuation.md

--- a/spec/fixtures/inlines/escapes.ass
+++ b/spec/fixtures/inlines/escapes.ass
@@ -161,7 +161,7 @@
 #           "\*": escape.constant.md
 #         }
 #         " "
-#         title.link.heading.markup.md {
+#         title.link.heading.support.markup.md {
 #           '"': punctuation.md
 #           "ti"
 #           "\*": escape.constant.md

--- a/spec/fixtures/inlines/escapes.ass
+++ b/spec/fixtures/inlines/escapes.ass
@@ -2,7 +2,7 @@
 
 @273
 "\!\"\#\$\%\&\'\(\)\*\+\,\-\.\/\:\;\<\=\>\?\@\[\\\]\^\_\`\{\|\}\~" {
-  text.md {
+  source.text.md {
     escape.constant.md {
       "\!"
       "\""
@@ -43,7 +43,7 @@
 # FIXME
 # @274
 # "\→\A\a\ \3\φ\«" {
-#   "\→\A\a\ \3\φ\«": text.md
+#   "\→\A\a\ \3\φ\«": source.text.md
 # }
 
 @275
@@ -55,7 +55,7 @@
 "\* not a list"+
 "\# not a header"+
 "\[foo]: /url "not a reference"" {
-  text.md {
+  source.text.md {
     "\*": escape.constant.md
     "not emphasized*"
     "\<": escape.constant.md
@@ -79,7 +79,7 @@
 # FIXME emphasis not detected
 # @276
 # "\\*emphasis*" {
-#   text.md {
+#   source.text.md {
 #     "\\": escape.constant.md
 #     emphasis.italic.markup.md {
 #       "*": punctuation.md
@@ -98,7 +98,7 @@
 
 @278
 "`` \[\` ``" {
-  text.md {
+  source.text.md {
     code.raw.markup.md {
       "``": punctuation.md
       " \[\` "
@@ -110,7 +110,7 @@
 # NOTE no indented-code-blocks
 @279
 "    \[\]" {
-  text.md {
+  source.text.md {
     "    "
     "\[": escape.constant.md
     "\]": escape.constant.md
@@ -121,7 +121,7 @@
 "~~~"+
 "\[\]"+
 "~~~" {
-  text.md {
+  source.text.md {
     fenced.code.md {
       "~~~": punctuation.md
       source.md {
@@ -147,7 +147,7 @@
 # FIXME escapes should work inside this
 # @283
 # "[foo](/bar\* "ti\*tle")" {
-#   text.md {
+#   source.text.md {
 #     link.md {
 #       text.link.string.md {
 #         "[": punctuation.md

--- a/spec/fixtures/inlines/images.ass
+++ b/spec/fixtures/inlines/images.ass
@@ -1,6 +1,6 @@
 @521
 "![foo](/url "title")" {
-  text.md {
+  source.text.md {
     link.markup.md {
       "![foo]" {
         image.link.string.md {
@@ -33,7 +33,7 @@
 # "![foo *bar*]"+
 # ""+
 # "[foo *bar*]: train.jpg "train & tracks"" {
-#   text.md {
+#   source.text.md {
 #
 #     "![foo *bar*]" {
 #       link.markup.md {
@@ -80,7 +80,7 @@
 # FIXME
 # @523
 # "![foo ![bar](/url)](/url2)" {
-#   text.md {
+#   source.text.md {
 #     link.markup.md {
 #       "![foo ![bar](/url)]" {
 #         image.link.string.md {
@@ -103,7 +103,7 @@
 # FIXME
 # @524
 # "![foo [bar](/url)](/url2)" {
-#   text.md {
+#   source.text.md {
 #     link.markup.md {
 #       "![foo [bar](/url)]" {
 #         image.link.string.md {
@@ -128,7 +128,7 @@
 # "![foo *bar*][]"+
 # ""+
 # "[foo *bar*]: train.jpg "train & tracks"" {
-#   text.md {
+#   source.text.md {
 #     "![foo *bar*][]" {
 #       link.markup.md {
 #         "![foo *bar*]" {
@@ -181,7 +181,7 @@
 # "![foo *bar*][foobar]"+
 # ""+
 # "[FOOBAR]: train.jpg "train & tracks"" {
-#   text.md {
+#   source.text.md {
 #     "![foo *bar*][foobar]" {
 #       link.markup.md {
 #         "![foo *bar*]" {
@@ -232,7 +232,7 @@
 
 @527
 "![foo](train.jpg)" {
-  text.md {
+  source.text.md {
     link.markup.md {
       "![foo]" {
         image.link.string.md {
@@ -254,7 +254,7 @@
 
 @528
 "My ![foo bar](/path/to/train.jpg  "title"   )" {
-  text.md {
+  source.text.md {
     "My "
     link.markup.md {
       "![foo bar]" {
@@ -286,7 +286,7 @@
 
 @529
 "![foo](<url>)" {
-  text.md {
+  source.text.md {
     link.markup.md {
       "![foo]" {
         image.link.string.md {
@@ -310,7 +310,7 @@
 
 @530
 "![](/url)" {
-  text.md {
+  source.text.md {
     link.markup.md {
       "![]" {
         image.link.string.md {
@@ -338,7 +338,7 @@
 # "![*foo* bar][]"+
 # ""+
 # "[*foo* bar]: /url "title"" {
-#   text.md {
+#   source.text.md {
 #     "![*foo* bar][]" {
 #       link.markup.md {
 #         "![*foo* bar]" {
@@ -395,7 +395,7 @@
 # "![*foo* bar]"+
 # ""+
 # "[*foo* bar]: /url "title"" {
-#   text.md {
+#   source.text.md {
 #     "![*foo* bar]" {
 #       link.markup.md {
 #         "![*foo* bar]" {
@@ -449,7 +449,7 @@
 # "![[foo]]"+
 # ""+
 # "[[foo]]: /url "title"" {
-#   text.md {
+#   source.text.md {
 #     "![[foo]]"
 #     ""
 #     "[[foo]]: /url "title""
@@ -462,7 +462,7 @@
 
 @541
 "\!\[foo]" {
-  text.md {
+  source.text.md {
     "\!": escape.constant.md
     "\[": escape.constant.md
     "foo]"
@@ -471,7 +471,7 @@
 
 @542
 "\![foo]" {
-  text.md {
+  source.text.md {
     "\!": escape.constant.md
     "[foo]" {
       label.link.string.md {

--- a/spec/fixtures/inlines/images.ass
+++ b/spec/fixtures/inlines/images.ass
@@ -1,7 +1,7 @@
 @521
 "![foo](/url "title")" {
   source.text.md {
-    link.markup.md {
+    link.markup.entity.md {
       "![foo]" {
         image.link.string.md {
           "![": punctuation.md
@@ -16,7 +16,7 @@
         }
         " "
         "title" {
-          title.link.md {
+          title.link.meta.md {
             """: punctuation.md
             "title"
             """: punctuation.md
@@ -36,7 +36,7 @@
 #   source.text.md {
 #
 #     "![foo *bar*]" {
-#       link.markup.md {
+#       link.markup.entity.md {
 #         image.link.string.md {
 #           "![": punctuation.md
 #           "foo *bar*"
@@ -48,7 +48,7 @@
 #     ""
 #
 #     "[foo *bar*]: train.jpg "train & tracks"" {
-#       reference.link.markup.md {
+#       reference.link.markup.entity.md {
 #         "[foo *bar*]" {
 #           text.link.string.md {
 #             "[": punctuation.md
@@ -65,7 +65,7 @@
 #         }
 #         " "
 #         ""train & tracks"" {
-#           title.link.md {
+#           title.link.meta.md {
 #             """: punctuation.md
 #             "train & tracks"
 #             """: punctuation.md
@@ -81,7 +81,7 @@
 # @523
 # "![foo ![bar](/url)](/url2)" {
 #   source.text.md {
-#     link.markup.md {
+#     link.markup.entity.md {
 #       "![foo ![bar](/url)]" {
 #         image.link.string.md {
 #           "![": punctuation.md
@@ -104,7 +104,7 @@
 # @524
 # "![foo [bar](/url)](/url2)" {
 #   source.text.md {
-#     link.markup.md {
+#     link.markup.entity.md {
 #       "![foo [bar](/url)]" {
 #         image.link.string.md {
 #           "![": punctuation.md
@@ -130,7 +130,7 @@
 # "[foo *bar*]: train.jpg "train & tracks"" {
 #   source.text.md {
 #     "![foo *bar*][]" {
-#       link.markup.md {
+#       link.markup.entity.md {
 #         "![foo *bar*]" {
 #           image.link.string.md {
 #             "![": punctuation.md
@@ -148,7 +148,7 @@
 #     }
 #     ""
 #     "[foo *bar*]: train.jpg "train & tracks"" {
-#       reference.link.markup.md {
+#       reference.link.markup.entity.md {
 #         "[foo *bar*]" {
 #           text.link.string.md {
 #             "[": punctuation.md
@@ -165,7 +165,7 @@
 #         }
 #         " "
 #         ""train & tracks"" {
-#           title.link.md {
+#           title.link.meta.md {
 #             """: punctuation.md
 #             "train & tracks"
 #             """: punctuation.md
@@ -183,7 +183,7 @@
 # "[FOOBAR]: train.jpg "train & tracks"" {
 #   source.text.md {
 #     "![foo *bar*][foobar]" {
-#       link.markup.md {
+#       link.markup.entity.md {
 #         "![foo *bar*]" {
 #           image.link.string.md {
 #             "![": punctuation.md
@@ -202,7 +202,7 @@
 #     }
 #     ""
 #     "[FOOBAR]: train.jpg "train & tracks"" {
-#       reference.link.markup.md {
+#       reference.link.markup.entity.md {
 #         "[FOOBAR]" {
 #           text.link.string.md {
 #             "[": punctuation.md
@@ -219,7 +219,7 @@
 #         }
 #         " "
 #         ""train & tracks"" {
-#           title.link.md {
+#           title.link.meta.md {
 #             """: punctuation.md
 #             "train & tracks"
 #             """: punctuation.md
@@ -233,7 +233,7 @@
 @527
 "![foo](train.jpg)" {
   source.text.md {
-    link.markup.md {
+    link.markup.entity.md {
       "![foo]" {
         image.link.string.md {
           "![": punctuation.md
@@ -256,7 +256,7 @@
 "My ![foo bar](/path/to/train.jpg  "title"   )" {
   source.text.md {
     "My "
-    link.markup.md {
+    link.markup.entity.md {
       "![foo bar]" {
         image.link.string.md {
           "![": punctuation.md
@@ -271,7 +271,7 @@
         }
         "  "
         "title" {
-          title.link.md {
+          title.link.meta.md {
             """: punctuation.md
             "title"
             """: punctuation.md
@@ -287,7 +287,7 @@
 @529
 "![foo](<url>)" {
   source.text.md {
-    link.markup.md {
+    link.markup.entity.md {
       "![foo]" {
         image.link.string.md {
           "![": punctuation.md
@@ -311,7 +311,7 @@
 @530
 "![](/url)" {
   source.text.md {
-    link.markup.md {
+    link.markup.entity.md {
       "![]" {
         image.link.string.md {
           "![": punctuation.md
@@ -340,7 +340,7 @@
 # "[*foo* bar]: /url "title"" {
 #   source.text.md {
 #     "![*foo* bar][]" {
-#       link.markup.md {
+#       link.markup.entity.md {
 #         "![*foo* bar]" {
 #           image.link.string.md {
 #             "![": punctuation.md
@@ -358,7 +358,7 @@
 #     }
 #     ""
 #     "[*foo* bar]: /url "title"" {
-#       reference.link.markup.md {
+#       reference.link.markup.entity.md {
 #         "[*foo* bar]" {
 #           label.link.string.md {
 #             "[": punctuation.md
@@ -375,7 +375,7 @@
 #         }
 #         " "
 #         ""title"" {
-#           title.link.md {
+#           title.link.meta.md {
 #             '"': punctuation.md
 #             "title"
 #             '"': punctuation.md
@@ -397,7 +397,7 @@
 # "[*foo* bar]: /url "title"" {
 #   source.text.md {
 #     "![*foo* bar]" {
-#       link.markup.md {
+#       link.markup.entity.md {
 #         "![*foo* bar]" {
 #           image.link.string.md {
 #             "![": punctuation.md
@@ -416,7 +416,7 @@
 #     }
 #     ""
 #     "[*foo* bar]: /url "title"" {
-#       reference.link.markup.md {
+#       reference.link.markup.entity.md {
 #         "[*foo* bar]" {
 #           label.link.string.md {
 #             "[": punctuation.md
@@ -433,7 +433,7 @@
 #         }
 #         " "
 #         ""title"" {
-#           title.link.md {
+#           title.link.meta.md {
 #             '"': punctuation.md
 #             "title"
 #             '"': punctuation.md

--- a/spec/fixtures/inlines/line-breaks.ass
+++ b/spec/fixtures/inlines/line-breaks.ass
@@ -3,7 +3,7 @@
 @580
 "foo  "+
 "baz" {
-  text.md {
+  source.text.md {
     "foo"
     "  ": line-break.constant.md
     "baz"
@@ -13,7 +13,7 @@
 @581
 "foo\"+
 "baz" {
-  text.md {
+  source.text.md {
     "foo"
     "\": line-break.constant.md
     "baz"
@@ -23,7 +23,7 @@
 @582
 "foo       "+
 "baz" {
-  text.md {
+  source.text.md {
     "foo     "
     "  ": line-break.constant.md
     "baz"
@@ -39,7 +39,7 @@
 @585
 "*foo  "+
 "bar*" {
-  text.md {
+  source.text.md {
     "*foo"
     "  ": line-break.constant.md
     "bar*"
@@ -50,7 +50,7 @@
 @586
 "*foo\"+
 "bar*" {
-  text.md {
+  source.text.md {
     "*foo"
     "\": line-break.constant.md
     "bar*"
@@ -61,7 +61,7 @@
 @587
 "`code  "+
 "span`" {
-  text.md {
+  source.text.md {
     "`code"
     "  ": line-break.constant.md
     "span`"
@@ -72,7 +72,7 @@
 @588
 "`code\"+
 "span`" {
-  text.md {
+  source.text.md {
     "`code"
     "\": line-break.constant.md
     "span`"
@@ -82,7 +82,7 @@
 @589
 "<a href="foo  "+
 "bar">" {
-  text.md {
+  source.text.md {
     "<a href="foo"
     "  ": line-break.constant.md
     "bar">"
@@ -92,7 +92,7 @@
 @590
 "<a href="foo\"+
 "bar">" {
-  text.md {
+  source.text.md {
     "<a href="foo"
     "\": line-break.constant.md
     "bar">"
@@ -101,7 +101,7 @@
 
 @591
 "foo\" {
-  text.md {
+  source.text.md {
     "foo"
     "\": line-break.constant.md
   }
@@ -109,7 +109,7 @@
 
 @592
 "foo  " {
-  text.md {
+  source.text.md {
     "foo"
     "  ": line-break.constant.md
   }
@@ -117,7 +117,7 @@
 
 @593
 "### foo\" {
-  text.md {
+  source.text.md {
     heading.markup.md {
       heading-3.md {
         '###': punctuation.md
@@ -130,7 +130,7 @@
 
 @594
 "### foo  " {
-  text.md {
+  source.text.md {
     heading.markup.md {
       heading-3.md {
         '###': punctuation.md
@@ -145,7 +145,7 @@
 @595
 "foo"+
 "baz" {
-  text.md {
+  source.text.md {
     "foo"
     "baz"
   }
@@ -154,7 +154,7 @@
 @596
 "foo "+
 " baz" {
-  text.md {
+  source.text.md {
     "foo "
     " baz"
   }

--- a/spec/fixtures/inlines/line-breaks.ass
+++ b/spec/fixtures/inlines/line-breaks.ass
@@ -118,7 +118,7 @@
 @593
 "### foo\" {
   source.text.md {
-    heading.markup.md {
+    heading.support.markup.md {
       heading-3.md {
         '###': punctuation.md
         ' '
@@ -131,7 +131,7 @@
 @594
 "### foo  " {
   source.text.md {
-    heading.markup.md {
+    heading.support.markup.md {
       heading-3.md {
         '###': punctuation.md
         ' '

--- a/spec/fixtures/inlines/links.ass
+++ b/spec/fixtures/inlines/links.ass
@@ -2,7 +2,7 @@
 
 @442
 "[link](/uri "title")" {
-  text.md {
+  source.text.md {
     link.markup.md {
       text.link.string.md {
         "[": punctuation.md
@@ -26,7 +26,7 @@
 
 @443
 "[link](/uri)" {
-  text.md {
+  source.text.md {
     link.markup.md {
       text.link.string.md {
         "[": punctuation.md
@@ -44,7 +44,7 @@
 
 @444
 "[link]()" {
-  text.md {
+  source.text.md {
     link.markup.md {
       text.link.string.md {
         "[": punctuation.md
@@ -59,7 +59,7 @@
 
 @445
 "[link](<>)" {
-  text.md {
+  source.text.md {
     link.markup.md {
       text.link.string.md {
         "[": punctuation.md
@@ -77,9 +77,9 @@
 }
 
 @446
-# "[link](/my uri)": text.md
+# "[link](/my uri)": source.text.md
 "[link](/my uri)" {
-  text.md {
+  source.text.md {
     "[link]" {
       label.link.string.md {
         "[": punctuation.md
@@ -93,7 +93,7 @@
 
 @447a
 "[link](</my uri>)" {
-  text.md {
+  source.text.md {
     link.markup.md {
       text.link.string.md {
         "[": punctuation.md
@@ -113,7 +113,7 @@
 
 @447b
 "[link](</my uri> "title")" {
-  text.md {
+  source.text.md {
     link.markup.md {
       text.link.string.md {
         "[": punctuation.md
@@ -140,7 +140,7 @@
 @448
 "[link](foo"+
 "bar)" {
-  text.md {
+  source.text.md {
     "[link]" {
       label.link.string.md {
         "[": punctuation.md
@@ -156,7 +156,7 @@
 @449
 "[link](<foo"+
 "bar>)" {
-  text.md {
+  source.text.md {
     "[link]" {
       label.link.string.md {
         "[": punctuation.md
@@ -171,7 +171,7 @@
 
 @450
 "[link]((foo)and(bar))" {
-  text.md {
+  source.text.md {
     link.markup.md {
       text.link.string.md {
         "[": punctuation.md
@@ -190,13 +190,13 @@
 # FIXME
 # @451
 # "[link](foo(and(bar)))" {
-#   "[link](foo(and(bar)))": text.md
+#   "[link](foo(and(bar)))": source.text.md
 # }
 
 # FIXME
 # @452
 # "[link](foo(and\(bar\)))" {
-#   text.md {
+#   source.text.md {
 #     link.markup.md {
 #       text.link.string.md {
 #         "[": punctuation.md
@@ -220,7 +220,7 @@
 
 @453
 "[link](<foo(and(bar))>)" {
-  text.md {
+  source.text.md {
     link.markup.md {
       text.link.string.md {
         "[": punctuation.md
@@ -241,7 +241,7 @@
 # FIXME
 # @454
 # "[link](foo\)\:)" {
-#   text.md {
+#   source.text.md {
 #     link.markup.md {
 #       text.link.string.md {
 #         "[": punctuation.md
@@ -263,7 +263,7 @@
 
 @455a
 "[link](#fragment)" {
-  text.md {
+  source.text.md {
     link.markup.md {
       text.link.string.md {
         "[": punctuation.md
@@ -281,7 +281,7 @@
 
 @455b
 "[link](http://example.com#fragment)" {
-  text.md {
+  source.text.md {
     link.markup.md {
       text.link.string.md {
         "[": punctuation.md
@@ -299,7 +299,7 @@
 
 @455c
 "[link](http://example.com?foo=bar&baz#fragment)" {
-  text.md {
+  source.text.md {
     link.markup.md {
       text.link.string.md {
         "[": punctuation.md
@@ -317,7 +317,7 @@
 
 @456
 "[link](foo\bar)" {
-  text.md {
+  source.text.md {
     link.markup.md {
       text.link.string.md {
         "[": punctuation.md
@@ -335,7 +335,7 @@
 
 @457
 "[link](foo%20b&auml;)" {
-  text.md {
+  source.text.md {
     link.markup.md {
       text.link.string.md {
         "[": punctuation.md
@@ -353,7 +353,7 @@
 
 @458
 "[link]("title")" {
-  text.md {
+  source.text.md {
     link.markup.md {
       text.link.string.md {
         "[": punctuation.md
@@ -371,7 +371,7 @@
 
 @459a
 "[link](/uri "title")" {
-  text.md {
+  source.text.md {
     link.markup.md {
       text.link.string.md {
         "[": punctuation.md
@@ -395,7 +395,7 @@
 
 @459b
 "[link](/uri 'title')" {
-  text.md {
+  source.text.md {
     link.markup.md {
       text.link.string.md {
         "[": punctuation.md
@@ -419,7 +419,7 @@
 
 @459b
 "[link](/uri (title))" {
-  text.md {
+  source.text.md {
     link.markup.md {
       text.link.string.md {
         "[": punctuation.md
@@ -444,7 +444,7 @@
 # FIXME
 # @460
 # "[link](/url "title \"&quot;")" {
-#   text.md {
+#   source.text.md {
 #     link.markup.md {
 #       text.link.string.md {
 #         "[": punctuation.md
@@ -471,12 +471,12 @@
 # FIXME
 # @461
 # "[link](/url "title "and" title")" {
-#   "[link](/url "title "and" title")": text.md
+#   "[link](/url "title "and" title")": source.text.md
 # }
 
 @462
 "[link](/url 'title "and" title')" {
-  text.md {
+  source.text.md {
     link.markup.md {
       text.link.string.md {
         "[": punctuation.md
@@ -506,9 +506,9 @@
 # }
 
 @464
-# "[link] (/uri)": text.md
+# "[link] (/uri)": source.text.md
 "[link] (/my uri)" {
-  text.md {
+  source.text.md {
     "[link]" {
       label.link.string.md {
         "[": punctuation.md
@@ -523,7 +523,7 @@
 # FIXME
 # @465
 # "[link [foo [bar]]](/uri)" {
-#   text.md {
+#   source.text.md {
 #     link.markup.md {
 #       text.link.string.md {
 #         "[": punctuation.md
@@ -541,7 +541,7 @@
 
 @466
 "[link] bar](/uri)" {
-  text.md {
+  source.text.md {
     "[link]" {
       label.link.string.md {
         "[": punctuation.md
@@ -556,7 +556,7 @@
 # FIXME
 # @467
 # "[link [bar](/uri)" {
-#   text.md {
+#   source.text.md {
 #     "[link "
 #     link.markup.md {
 #       text.link.string.md {
@@ -576,7 +576,7 @@
 # FIXME
 # @468
 # "[link \[bar](/uri)" {
-#   text.md {
+#   source.text.md {
 #     link.markup.md {
 #       text.link.string.md {
 #         "[": punctuation.md
@@ -597,7 +597,7 @@
 # FIXME
 # @469a
 # "[link *foo **bar** `#`*](/uri)" {
-#   text.md {
+#   source.text.md {
 #     link.markup.md {
 #       text.link.string.md {
 #         "[": punctuation.md
@@ -631,7 +631,7 @@
 
 @469b
 "[link _foo **bar** `#`_](/uri)" {
-  text.md {
+  source.text.md {
     link.markup.md {
       text.link.string.md {
         "[": punctuation.md
@@ -665,7 +665,7 @@
 
 @470
 "[![moon](moon.jpg)](/uri)" {
-  text.md {
+  source.text.md {
     link.markup.md {
       text.link.string.md {
         "[": punctuation.md
@@ -699,7 +699,7 @@
 # FIXME
 # @471
 # "[foo [bar](/uri)](/uri)" {
-#   text.md {
+#   source.text.md {
 #     "[foo "
 #
 #     "[bar](/uri)" {
@@ -723,7 +723,7 @@
 
 # @472
 # "[foo *[bar [baz](/uri)](/uri)*](/uri)" {
-#   text.md {
+#   source.text.md {
 #     "[foo "
 #     "*[bar [baz](/uri)](/uri)*" {
 #       emphasis.italic.markup.md {
@@ -760,7 +760,7 @@
 # FIXME
 # @474
 # "*[foo*](/uri)" {
-#   text.md {
+#   source.text.md {
 #     "*"
 #     link.markup.md {
 #       text.link.string.md {
@@ -779,7 +779,7 @@
 
 @475
 "[foo *bar](baz*)" {
-  text.md {
+  source.text.md {
     link.markup.md {
       text.link.string.md {
         "[": punctuation.md
@@ -797,7 +797,7 @@
 
 @476
 "*foo [bar* baz]" {
-  text.md {
+  source.text.md {
     emphasis.italic.markup.md {
       "*": punctuation.md
       "foo [bar"
@@ -809,11 +809,11 @@
 
 # FIXME
 # @477
-# "[foo <bar attr="](baz)">": text.md
+# "[foo <bar attr="](baz)">": source.text.md
 
 # @478
 # "[foo`](/uri)`" {
-#   text.md {
+#   source.text.md {
 #     "[foo"
 #     "`](/uri)`" {
 #       code.raw.markup.md {
@@ -827,13 +827,13 @@
 
 # FIXME
 # @479
-# "[foo<http://example.com/?search=](uri)>": text.md
+# "[foo<http://example.com/?search=](uri)>": source.text.md
 
 @480
 "[foo][bar]"+
 ""+
 "[bar]: /url "title"" {
-  text.md {
+  source.text.md {
     "[foo][bar]" {
       link.markup.md {
         "[foo]" {
@@ -887,7 +887,7 @@
 # "[link [foo [bar]]][ref]"+
 # ""+
 # "[ref]: /uri" {
-#   text.md {
+#   source.text.md {
 #     # NOTE Nested square-brackets are not supported
 #     "[link [foo [bar]]][ref]" {
 #       link.markup.md {
@@ -934,7 +934,7 @@
 # "[link \[bar][ref]"+
 # ""+
 # "[ref]: /uri" {
-#   text.md {
+#   source.text.md {
 #     # NOTE Escaped square-brackets are not supported
 #     "[link \[bar][ref]" {
 #       link.markup.md {
@@ -988,7 +988,7 @@
 "[link _foo **bar** `#`_][ref]"+
 ""+
 "[ref]: /uri" {
-  text.md {
+  source.text.md {
     "[link _foo **bar** `#`_][ref]" {
       link.markup.md {
         "[link _foo **bar** `#`_]" {
@@ -1053,7 +1053,7 @@
 
 @484
 "[![moon](moon.jpg)][ref]" {
-  text.md {
+  source.text.md {
     link.markup.md {
       text.link.string.md {
         "[": punctuation.md
@@ -1146,7 +1146,7 @@
 "[Толпой][Толпой] is a Russian word."+
 ""+
 "[ТОЛПОЙ]: /url" {
-  text.md {
+  source.text.md {
     "[Толпой][Толпой]" {
       link.markup.md {
         "[Толпой]" {
@@ -1192,7 +1192,7 @@
 @494
 "[Foo"+
 "  bar]: /url" {
-  text.md {
+  source.text.md {
     "[Foo"
     "  bar]: /url"
   }
@@ -1206,7 +1206,7 @@
 "[bar][foo\!]"+
 ""+
 "[foo!]: /url" {
-  text.md {
+  source.text.md {
     "[bar][foo\!]" {
       link.markup.md {
         "[bar]" {
@@ -1252,7 +1252,7 @@
 # "[foo][ref[]"+
 # ""+
 # "[ref[]: /uri" {
-#   text.md {
+#   source.text.md {
 #     "[foo][ref[]" {
 #       link.markup.md {
 #         "[foo]" {
@@ -1314,7 +1314,7 @@
 # "[foo][ref\[]"+
 # ""+
 # "[ref\[]: /uri" {
-#   text.md {
+#   source.text.md {
 #     "[foo][ref\[]" {
 #       link.markup.md {
 #         "[foo]" {
@@ -1360,7 +1360,7 @@
 "[]"+
 ""+
 "[]: /uri" {
-  text.md {
+  source.text.md {
     "[]" {
       label.link.string.md {
         "[": punctuation.md
@@ -1394,7 +1394,7 @@
 ""+
 "["+
 " ]: /uri" {
-  text.md {
+  source.text.md {
     "["
     " ]"
     ""
@@ -1413,7 +1413,7 @@
 # "[*foo* bar]"+
 # ""+
 # "[*foo* bar]: /url "title"" {
-#   text.md {
+#   source.text.md {
 #     "[*foo* bar]" {
 #       label.link.string.md {
 #         "[": punctuation.md
@@ -1482,7 +1482,7 @@
 "\[foo]"+
 ""+
 "[foo]: /url "title"" {
-  text.md {
+  source.text.md {
     "\[": escape.constant.md
     "foo]"
     ""
@@ -1525,7 +1525,7 @@
 
 @517
 "[foo][bar]" {
-  text.md {
+  source.text.md {
     "[foo][bar]" {
       link.markup.md {
         "[foo]" {
@@ -1551,7 +1551,7 @@
 # The three [link-labels] aren't detected as such, but are displayed how they should. And who would do such a thing anyway?
 @518
 "[foo][bar][baz]" {
-  text.md {
+  source.text.md {
     "[foo][bar][baz]" {
       "[foo][bar]" {
         link.markup.md {

--- a/spec/fixtures/inlines/links.ass
+++ b/spec/fixtures/inlines/links.ass
@@ -3,7 +3,7 @@
 @442
 "[link](/uri "title")" {
   source.text.md {
-    link.markup.md {
+    link.markup.entity.md {
       text.link.string.md {
         "[": punctuation.md
         "link"
@@ -14,7 +14,7 @@
         "/uri": uri.underline.link.md
       }
       ' '
-      title.link.md {
+      title.link.meta.md {
         '"': punctuation.md
         "title"
         '"': punctuation.md
@@ -27,7 +27,7 @@
 @443
 "[link](/uri)" {
   source.text.md {
-    link.markup.md {
+    link.markup.entity.md {
       text.link.string.md {
         "[": punctuation.md
         "link"
@@ -45,7 +45,7 @@
 @444
 "[link]()" {
   source.text.md {
-    link.markup.md {
+    link.markup.entity.md {
       text.link.string.md {
         "[": punctuation.md
         "link"
@@ -60,7 +60,7 @@
 @445
 "[link](<>)" {
   source.text.md {
-    link.markup.md {
+    link.markup.entity.md {
       text.link.string.md {
         "[": punctuation.md
         "link"
@@ -94,7 +94,7 @@
 @447a
 "[link](</my uri>)" {
   source.text.md {
-    link.markup.md {
+    link.markup.entity.md {
       text.link.string.md {
         "[": punctuation.md
         "link"
@@ -114,7 +114,7 @@
 @447b
 "[link](</my uri> "title")" {
   source.text.md {
-    link.markup.md {
+    link.markup.entity.md {
       text.link.string.md {
         "[": punctuation.md
         "link"
@@ -127,7 +127,7 @@
         ">": punctuation.md
       }
       ' '
-      title.link.md {
+      title.link.meta.md {
         '"': punctuation.md
         "title"
         '"': punctuation.md
@@ -172,7 +172,7 @@
 @450
 "[link]((foo)and(bar))" {
   source.text.md {
-    link.markup.md {
+    link.markup.entity.md {
       text.link.string.md {
         "[": punctuation.md
         "link"
@@ -197,7 +197,7 @@
 # @452
 # "[link](foo(and\(bar\)))" {
 #   source.text.md {
-#     link.markup.md {
+#     link.markup.entity.md {
 #       text.link.string.md {
 #         "[": punctuation.md
 #         "link"
@@ -221,7 +221,7 @@
 @453
 "[link](<foo(and(bar))>)" {
   source.text.md {
-    link.markup.md {
+    link.markup.entity.md {
       text.link.string.md {
         "[": punctuation.md
         "link"
@@ -242,7 +242,7 @@
 # @454
 # "[link](foo\)\:)" {
 #   source.text.md {
-#     link.markup.md {
+#     link.markup.entity.md {
 #       text.link.string.md {
 #         "[": punctuation.md
 #         "link"
@@ -264,7 +264,7 @@
 @455a
 "[link](#fragment)" {
   source.text.md {
-    link.markup.md {
+    link.markup.entity.md {
       text.link.string.md {
         "[": punctuation.md
         "link"
@@ -282,7 +282,7 @@
 @455b
 "[link](http://example.com#fragment)" {
   source.text.md {
-    link.markup.md {
+    link.markup.entity.md {
       text.link.string.md {
         "[": punctuation.md
         "link"
@@ -300,7 +300,7 @@
 @455c
 "[link](http://example.com?foo=bar&baz#fragment)" {
   source.text.md {
-    link.markup.md {
+    link.markup.entity.md {
       text.link.string.md {
         "[": punctuation.md
         "link"
@@ -318,7 +318,7 @@
 @456
 "[link](foo\bar)" {
   source.text.md {
-    link.markup.md {
+    link.markup.entity.md {
       text.link.string.md {
         "[": punctuation.md
         "link"
@@ -336,7 +336,7 @@
 @457
 "[link](foo%20b&auml;)" {
   source.text.md {
-    link.markup.md {
+    link.markup.entity.md {
       text.link.string.md {
         "[": punctuation.md
         "link"
@@ -354,7 +354,7 @@
 @458
 "[link]("title")" {
   source.text.md {
-    link.markup.md {
+    link.markup.entity.md {
       text.link.string.md {
         "[": punctuation.md
         "link"
@@ -372,7 +372,7 @@
 @459a
 "[link](/uri "title")" {
   source.text.md {
-    link.markup.md {
+    link.markup.entity.md {
       text.link.string.md {
         "[": punctuation.md
         "link"
@@ -383,7 +383,7 @@
         "/uri": uri.underline.link.md
       }
       ' '
-      title.link.md {
+      title.link.meta.md {
         '"': punctuation.md
         "title"
         '"': punctuation.md
@@ -396,7 +396,7 @@
 @459b
 "[link](/uri 'title')" {
   source.text.md {
-    link.markup.md {
+    link.markup.entity.md {
       text.link.string.md {
         "[": punctuation.md
         "link"
@@ -407,7 +407,7 @@
         "/uri": uri.underline.link.md
       }
       ' '
-      title.link.md {
+      title.link.meta.md {
         ''': punctuation.md
         "title"
         ''': punctuation.md
@@ -420,7 +420,7 @@
 @459b
 "[link](/uri (title))" {
   source.text.md {
-    link.markup.md {
+    link.markup.entity.md {
       text.link.string.md {
         "[": punctuation.md
         "link"
@@ -431,7 +431,7 @@
         "/uri": uri.underline.link.md
       }
       ' '
-      title.link.md {
+      title.link.meta.md {
         '(': punctuation.md
         "title"
         ')': punctuation.md
@@ -445,7 +445,7 @@
 # @460
 # "[link](/url "title \"&quot;")" {
 #   source.text.md {
-#     link.markup.md {
+#     link.markup.entity.md {
 #       text.link.string.md {
 #         "[": punctuation.md
 #         "link"
@@ -456,7 +456,7 @@
 #         "/uri": uri.underline.link.md
 #       }
 #       ' '
-#       title.link.md {
+#       title.link.meta.md {
 #         '"': punctuation.md
 #         "title "
 #         "\"": escape.constant.md
@@ -477,7 +477,7 @@
 @462
 "[link](/url 'title "and" title')" {
   source.text.md {
-    link.markup.md {
+    link.markup.entity.md {
       text.link.string.md {
         "[": punctuation.md
         "link"
@@ -488,7 +488,7 @@
         "/url": uri.underline.link.md
       }
       ' '
-      title.link.md {
+      title.link.meta.md {
         ''': punctuation.md
         "title "and" title"
         ''': punctuation.md
@@ -524,7 +524,7 @@
 # @465
 # "[link [foo [bar]]](/uri)" {
 #   source.text.md {
-#     link.markup.md {
+#     link.markup.entity.md {
 #       text.link.string.md {
 #         "[": punctuation.md
 #         "link [foo [bar]]"
@@ -558,7 +558,7 @@
 # "[link [bar](/uri)" {
 #   source.text.md {
 #     "[link "
-#     link.markup.md {
+#     link.markup.entity.md {
 #       text.link.string.md {
 #         "[": punctuation.md
 #         "bar"
@@ -577,7 +577,7 @@
 # @468
 # "[link \[bar](/uri)" {
 #   source.text.md {
-#     link.markup.md {
+#     link.markup.entity.md {
 #       text.link.string.md {
 #         "[": punctuation.md
 #         "link "
@@ -598,7 +598,7 @@
 # @469a
 # "[link *foo **bar** `#`*](/uri)" {
 #   source.text.md {
-#     link.markup.md {
+#     link.markup.entity.md {
 #       text.link.string.md {
 #         "[": punctuation.md
 #         "link "
@@ -632,7 +632,7 @@
 @469b
 "[link _foo **bar** `#`_](/uri)" {
   source.text.md {
-    link.markup.md {
+    link.markup.entity.md {
       text.link.string.md {
         "[": punctuation.md
         "link "
@@ -666,12 +666,12 @@
 @470
 "[![moon](moon.jpg)](/uri)" {
   source.text.md {
-    link.markup.md {
+    link.markup.entity.md {
       text.link.string.md {
         "[": punctuation.md
 
         "![moon](moon.jpg)" {
-          link.markup.md {
+          link.markup.entity.md {
             image.link.string.md {
               "![": punctuation.md
               "moon"
@@ -703,7 +703,7 @@
 #     "[foo "
 #
 #     "[bar](/uri)" {
-#       link.markup.md {
+#       link.markup.entity.md {
 #         text.link.string.md {
 #           "[": punctuation.md
 #           "bar"
@@ -730,7 +730,7 @@
 #         "*": punctuation.md
 #         "[bar "
 #         "[baz](/uri)" {
-#           link.markup.md {
+#           link.markup.entity.md {
 #             text.link.string.md {
 #               "[": punctuation.md
 #               "baz"
@@ -762,7 +762,7 @@
 # "*[foo*](/uri)" {
 #   source.text.md {
 #     "*"
-#     link.markup.md {
+#     link.markup.entity.md {
 #       text.link.string.md {
 #         "[": punctuation.md
 #         "foo*"
@@ -780,7 +780,7 @@
 @475
 "[foo *bar](baz*)" {
   source.text.md {
-    link.markup.md {
+    link.markup.entity.md {
       text.link.string.md {
         "[": punctuation.md
         "foo *bar"
@@ -835,7 +835,7 @@
 "[bar]: /url "title"" {
   source.text.md {
     "[foo][bar]" {
-      link.markup.md {
+      link.markup.entity.md {
         "[foo]" {
           text.link.string.md {
             "[": punctuation.md
@@ -854,7 +854,7 @@
     }
     ""
     "[bar]: /url "title"" {
-      reference.link.markup.md {
+      reference.link.markup.entity.md {
         "[bar]" {
           label.link.string.md {
             "[": punctuation.md
@@ -871,7 +871,7 @@
         }
         " "
         ""title"" {
-          title.link.md {
+          title.link.meta.md {
             '"': punctuation.md
             "title"
             '"': punctuation.md
@@ -890,7 +890,7 @@
 #   source.text.md {
 #     # NOTE Nested square-brackets are not supported
 #     "[link [foo [bar]]][ref]" {
-#       link.markup.md {
+#       link.markup.entity.md {
 #         "[link [foo [bar]]]" {
 #           text.link.string.md {
 #             "[": punctuation.md
@@ -909,7 +909,7 @@
 #     }
 #     ""
 #     "[ref]: /uri" {
-#       reference.link.markup.md {
+#       reference.link.markup.entity.md {
 #         "[ref]" {
 #           label.link.string.md {
 #             "[": punctuation.md
@@ -937,7 +937,7 @@
 #   source.text.md {
 #     # NOTE Escaped square-brackets are not supported
 #     "[link \[bar][ref]" {
-#       link.markup.md {
+#       link.markup.entity.md {
 #         "[link \[bar]" {
 #           text.link.string.md {
 #             "[": punctuation.md
@@ -956,7 +956,7 @@
 #     }
 #     ""
 #     "[ref]: /uri" {
-#       reference.link.markup.md {
+#       reference.link.markup.entity.md {
 #         "[ref]" {
 #           label.link.string.md {
 #             "[": punctuation.md
@@ -990,7 +990,7 @@
 "[ref]: /uri" {
   source.text.md {
     "[link _foo **bar** `#`_][ref]" {
-      link.markup.md {
+      link.markup.entity.md {
         "[link _foo **bar** `#`_]" {
           text.link.string.md {
             "[": punctuation.md
@@ -1031,7 +1031,7 @@
     }
     ""
     "[ref]: /uri" {
-      reference.link.markup.md {
+      reference.link.markup.entity.md {
         "[ref]" {
           label.link.string.md {
             "[": punctuation.md
@@ -1054,12 +1054,12 @@
 @484
 "[![moon](moon.jpg)][ref]" {
   source.text.md {
-    link.markup.md {
+    link.markup.entity.md {
       text.link.string.md {
         "[": punctuation.md
 
         "![moon](moon.jpg)" {
-          link.markup.md {
+          link.markup.entity.md {
             image.link.string.md {
               "![": punctuation.md
               "moon"
@@ -1148,7 +1148,7 @@
 "[ТОЛПОЙ]: /url" {
   source.text.md {
     "[Толпой][Толпой]" {
-      link.markup.md {
+      link.markup.entity.md {
         "[Толпой]" {
           text.link.string.md {
             "[": punctuation.md
@@ -1168,7 +1168,7 @@
     " is a Russian word."
     ""
     "[ТОЛПОЙ]: /url" {
-      reference.link.markup.md {
+      reference.link.markup.entity.md {
         "[ТОЛПОЙ]" {
           label.link.string.md {
             "[": punctuation.md
@@ -1208,7 +1208,7 @@
 "[foo!]: /url" {
   source.text.md {
     "[bar][foo\!]" {
-      link.markup.md {
+      link.markup.entity.md {
         "[bar]" {
           text.link.string.md {
             "[": punctuation.md
@@ -1227,7 +1227,7 @@
     }
     ""
     "[foo!]: /url" {
-      reference.link.markup.md {
+      reference.link.markup.entity.md {
         "[foo!]" {
           label.link.string.md {
             "[": punctuation.md
@@ -1254,7 +1254,7 @@
 # "[ref[]: /uri" {
 #   source.text.md {
 #     "[foo][ref[]" {
-#       link.markup.md {
+#       link.markup.entity.md {
 #         "[foo]" {
 #           text.link.string.md {
 #             "[": punctuation.md
@@ -1273,7 +1273,7 @@
 #     }
 #     ""
 #     "[ref[]: /uri" {
-#       reference.link.markup.md {
+#       reference.link.markup.entity.md {
 #         "[ref[]" {
 #           label.link.string.md {
 #             "[": punctuation.md
@@ -1316,7 +1316,7 @@
 # "[ref\[]: /uri" {
 #   source.text.md {
 #     "[foo][ref\[]" {
-#       link.markup.md {
+#       link.markup.entity.md {
 #         "[foo]" {
 #           text.link.string.md {
 #             "[": punctuation.md
@@ -1335,7 +1335,7 @@
 #     }
 #     ""
 #     "[ref\[]: /uri" {
-#       reference.link.markup.md {
+#       reference.link.markup.entity.md {
 #         "[ref\[]" {
 #           label.link.string.md {
 #             "[": punctuation.md
@@ -1369,7 +1369,7 @@
     }
     ""
     "[]: /uri" {
-      reference.link.markup.md {
+      reference.link.markup.entity.md {
         "[]" {
           label.link.string.md {
             "[": punctuation.md
@@ -1430,7 +1430,7 @@
 #     }
 #     ""
 #     "[*foo* bar]: /url "title"" {
-#       reference.link.markup.md {
+#       reference.link.markup.entity.md {
 #         "[*foo* bar]" {
 #           label.link.string.md {
 #             "[": punctuation.md
@@ -1447,7 +1447,7 @@
 #         }
 #         " "
 #         ""title"" {
-#           title.link.md {
+#           title.link.meta.md {
 #             '"': punctuation.md
 #             "title"
 #             '"': punctuation.md
@@ -1487,7 +1487,7 @@
     "foo]"
     ""
     "[foo]: /url "title"" {
-      reference.link.markup.md {
+      reference.link.markup.entity.md {
         "[foo]" {
           label.link.string.md {
             "[": punctuation.md
@@ -1504,7 +1504,7 @@
         }
         " "
         ""title"" {
-          title.link.md {
+          title.link.meta.md {
             '"': punctuation.md
             "title"
             '"': punctuation.md
@@ -1527,7 +1527,7 @@
 "[foo][bar]" {
   source.text.md {
     "[foo][bar]" {
-      link.markup.md {
+      link.markup.entity.md {
         "[foo]" {
           text.link.string.md {
             "[": punctuation.md
@@ -1554,7 +1554,7 @@
   source.text.md {
     "[foo][bar][baz]" {
       "[foo][bar]" {
-        link.markup.md {
+        link.markup.entity.md {
           "[foo]" {
             text.link.string.md {
               "[": punctuation.md

--- a/spec/fixtures/inlines/textual-content.ass
+++ b/spec/fixtures/inlines/textual-content.ass
@@ -1,13 +1,13 @@
 # http://spec.commonmark.org/0.22/#textual-content
 
 @597
-"hello $.;'there": text.md
+"hello $.;'there": source.text.md
 
 @598
-"Foo χρῆν": text.md
+"Foo χρῆν": source.text.md
 
 @599
-"Multiple     spaces": text.md
+"Multiple     spaces": source.text.md
 
 @space
-" ": text.md
+" ": source.text.md

--- a/spec/fixtures/issues.ass
+++ b/spec/fixtures/issues.ass
@@ -1,6 +1,6 @@
 @40
 "At the base is the old friend, Wordpress [update: this is old news, it's running [Statamic](http://www.statamic.com) now. But this still should be interesting]." {
-  text.md {
+  source.text.md {
     "At the base is the old friend, Wordpress [update: this is old news, it's running "
     "[Statamic](http://www.statamic.com)" {
       link.markup.md {
@@ -24,7 +24,7 @@
 # NOTE expected outcome: only emphasize first letters of words
 @gfm/117a
 "*f*oo *b*ar baz" {
-  text.md {
+  source.text.md {
     emphasis.italic.markup.md {
       "*": punctuation.md
       "f"
@@ -42,7 +42,7 @@
 
 @gfm/117b
 "**f**oo **b**ar baz" {
-  text.md {
+  source.text.md {
     strong.emphasis.bold.markup.md {
       "**": punctuation.md
       "f"
@@ -61,7 +61,7 @@
 # https://github.com/burodepeper/language-markdown/issues/17
 @17a
 "A line with *italics* and **bold** fails." {
-  text.md {
+  source.text.md {
     "A line with "
     emphasis.italic.markup.md {
       "*": punctuation.md
@@ -80,7 +80,7 @@
 
 @17b
 "Even _mixing_ the **type** of *markers* is __not enough__." {
-  text.md {
+  source.text.md {
     "Even "
     emphasis.italic.markup.md {
       "_": punctuation.md

--- a/spec/fixtures/issues.ass
+++ b/spec/fixtures/issues.ass
@@ -3,7 +3,7 @@
   source.text.md {
     "At the base is the old friend, Wordpress [update: this is old news, it's running "
     "[Statamic](http://www.statamic.com)" {
-      link.markup.md {
+      link.markup.entity.md {
         text.link.string.md {
           "[": punctuation.md
           "Statamic"


### PR DESCRIPTION
- [x] Switch default scope to `source.text.md`
- [x] Add a `markup-and-down.less` resource file to enable quick and easy patching of syntax-themes
  - [x] Set up framework for generic markup styles
  - [x] Expand framework with custom markdown styles
  - [x] Test resource file via `minimal-syntax`, and add scopes wherever necessary
- [x] Test default syntax themes with and without patch
- [ ] BUG: `markdown-preview` doesn't work with the changed base scope; perhaps this can better be solved in that package. (see https://github.com/atom/markdown-preview/issues/384)
- [ ] Create patches for default syntax themes
  - [ ] Atom Dark
  - [ ] Atom Light
  - [ ] base16 Tomorrow Dark
  - [ ] base16 Tomorrow Light
  - [ ] One Dark
  - [ ] One Light
  - [ ] Solarized Dark
  - [ ] Solarized Light
- [ ] Create patches for popular syntax themes
  - [ ] Monokai (https://github.com/kevinsawicki/monokai/pull/68)