### PR TITLE
Add R Markdown support (part deux)

### DIFF
--- a/grammars/repositories/flavors/rmarkdown-attributes.cson
+++ b/grammars/repositories/flavors/rmarkdown-attributes.cson
@@ -1,3 +1,9 @@
+# TODO
+# ```{r cache.rebuild=!file.exists("path/to/file.ext")}
+# ```{r dev=c('pdf', 'tiff'), dev.args=list(pdf = list(colormodel = 'cmyk', useDingats = TRUE), tiff = list(compression = 'lzw'))}
+# ```{r code=capture.output(dump('fivenum', ''))}
+# ```{r fig.cap=paste('p-value is', t.test(x)$p.value)}
+
 key: 'rmarkdown-attributes'
 patterns: [
 


### PR DESCRIPTION
- [ ] Add better/wider support for using functions as attribute values (ie, `{r code=capture.output(dump('fivenum', ''))}`)
- [ ] Use value of `engine` attribute to parse the contents of the code-block