### PR TITLE
Add link and image commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ If you experience any issue above a reasonable/tolerable level of annoyancy, don
   - Toggle tasks with <kbd>cmd+shift+x</kbd> or <kbd>ctrl+shift+x</kbd>
   - Remove empty trailing list-items when pressing <kbd>enter</kbd>
 - Adds shortcuts (via <kbd>_</kbd>, <kbd>*</kbd> and <kbd>~</kbd>) for toggling inline-emphasis and strike-through on selected text
+- Add shortcut (via <kbd>@</kbd>) for converting selected text to a link
+- Add shortcut (via <kbd>!</kbd>) for converting selected text to a link
 - Supports embedded `HTML`- and `Liquid`-tags
 - Embedded math functions (via `language-latex`)
 

--- a/keymaps/markdown.cson
+++ b/keymaps/markdown.cson
@@ -18,3 +18,5 @@
   '_': 'markdown:emphasis'
   '*': 'markdown:strong-emphasis'
   '~': 'markdown:strike-through'
+  '@': 'markdown:link'
+  '!': 'markdown:image'

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -59,7 +59,7 @@ module.exports =
     
     # Add command for linkifying selections
     @subscriptions.add atom.commands.add 'atom-text-editor', 'markdown:link': (event) => @linkSelection(event)
-    @subscriptions.add atom.commands.add 'atom-text-editor', 'markdown:image': (event) => @imageSelection(event)
+    @subscriptions.add atom.commands.add 'atom-text-editor', 'markdown:image': (event) => @linkSelection(event, true)
 
     # Add command to toggle a task
     @subscriptions.add atom.commands.add 'atom-text-editor', 'markdown:toggle-task': (event) => @toggleTask(event)
@@ -189,19 +189,20 @@ module.exports =
     else
       event.abortKeyBinding()
       
-  linkSelection: (event) ->
+  linkSelection: (event, isImage) ->
     if atom.config.get('language-markdown.linkShortcuts')
       {editor, position} = @_getEditorAndPosition(event)
       text = editor.getSelectedText()
       if text
         # Multi-line emphasis is not supported, so the command is aborted when a new-line is detected in the selection
         if text.indexOf("\n") is -1
+          imageToken = if isImage then '!' else ''
           if text.match(/[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/)
-            editor.insertText('[](' + text + ')')
+            editor.insertText(imageToken + '[](' + text + ')')
             {editor, position} = @_getEditorAndPosition(event)
             editor.setCursorBufferPosition([position.row, position.column - (text.length + 3)])
           else
-            editor.insertText('[' + text + ']()')
+            editor.insertText(imageToken + '[' + text + ']()')
             {editor, position} = @_getEditorAndPosition(event)
             editor.setCursorBufferPosition([position.row, position.column - 1])
         else
@@ -211,28 +212,6 @@ module.exports =
     else
       event.abortKeyBinding()
       
-  imageSelection: (event) ->
-    if atom.config.get('language-markdown.linkShortcuts')
-      {editor, position} = @_getEditorAndPosition(event)
-      text = editor.getSelectedText()
-      if text
-        # Multi-line emphasis is not supported, so the command is aborted when a new-line is detected in the selection
-        if text.indexOf("\n") is -1
-          if text.match(/[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/)
-            editor.insertText('![](' + text + ')')
-            {editor, position} = @_getEditorAndPosition(event)
-            editor.setCursorBufferPosition([position.row, position.column - (text.length + 3)])
-          else
-            editor.insertText('![' + text + ']()')
-            {editor, position} = @_getEditorAndPosition(event)
-            editor.setCursorBufferPosition([position.row, position.column - 1])
-        else
-          event.abortKeyBinding()
-      else
-        event.abortKeyBinding()
-    else
-      event.abortKeyBinding()
-
   _wrapSelection: (text, token) ->
     # unwrap selection
     if (text.substr(0, token.length) is token) and (text.substr(-token.length) is token)

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -31,15 +31,9 @@ module.exports =
       type: 'boolean'
       default: true
       
-    linkShortcut:
-      title: 'Link shortcut'
-      description: 'Enables keybindings for converting the selected text to a link'
-      type: 'boolean'
-      default: true
-      
-    imageShortcut:
-      title: 'Image shortcut'
-      description: 'Enables keybindings for converting the selected text to an image'
+    linkShortcuts:
+      title: 'Link shortcuts'
+      description: 'Enables keybindings `@` for converting the selected text to a link and `!` for converting the selected text to an image'
       type: 'boolean'
       default: true
 
@@ -196,7 +190,7 @@ module.exports =
       event.abortKeyBinding()
       
   linkSelection: (event) ->
-    if atom.config.get('language-markdown.linkShortcut')
+    if atom.config.get('language-markdown.linkShortcuts')
       {editor, position} = @_getEditorAndPosition(event)
       text = editor.getSelectedText()
       if text
@@ -218,7 +212,7 @@ module.exports =
       event.abortKeyBinding()
       
   imageSelection: (event) ->
-    if atom.config.get('language-markdown.imageShortcut')
+    if atom.config.get('language-markdown.linkShortcuts')
       {editor, position} = @_getEditorAndPosition(event)
       text = editor.getSelectedText()
       if text

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -198,6 +198,7 @@ module.exports =
         if text.indexOf("\n") is -1
           imageToken = if isImage then '!' else ''
           if text.match(/[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/)
+            # if text.match(/\.(jpg|jpeg|png|gif|tiff)/) then imageToken = '!'
             editor.insertText(imageToken + '[](' + text + ')')
             {editor, position} = @_getEditorAndPosition(event)
             editor.setCursorBufferPosition([position.row, position.column - (text.length + 3)])


### PR DESCRIPTION
Use “Markdown: Link” or <kbd>cmd+k</kbd> (twice, not sure why it behaves this way) or <kbd>@</kbd> to add link brackets to non-URL text selection or link parenthesis around URL text selection.

Link non-URL selection:

![non-url](http://g.recordit.co/DkHEXc4nzs.gif)

Link URL selection:

![url](http://g.recordit.co/xGmDnNahX9.gif)

Room for improvement:

- [ ] Make keyboard shortcut simply <kbd>cmd+k</kbd> (vs. <kbd>cmd+k</kbd> twice)
- [x] Reposition cursor between empty brackets/parenthesis

I've enabled "Allow edits from maintainers" so you can make modifications if necessary.