### PR TITLE
Fix syntactic error

### DIFF
--- a/lib/__main.js
+++ b/lib/__main.js
@@ -12,7 +12,7 @@ module.exports = {
   config: {
     addListItems: {
       title: 'Add new list-items',
-      description: 'Automatically add a new list-item after the current (non-empty) one when pressing <kbd>ENTER</kbd>'
+      description: 'Automatically add a new list-item after the current (non-empty) one when pressing <kbd>ENTER</kbd>',
       type: 'boolean'
       default: true
     },
@@ -44,7 +44,7 @@ module.exports = {
       type: 'boolean',
       default: true
     },
-    
+
     removeEmptyListItems: {
       title: 'Remove empty list-items',
       description: 'Remove the automatically created empty list-items when left empty, leaving an empty line',


### PR DESCRIPTION
In the process of upgrading babel in Atom core (https://github.com/atom/atom/pull/13823) we have noticed this package uses JavaScript features that are either deprecated or that are incompatible with the language specification.

This pull request changes the code to stop using such features so that the package keeps working when the babel upgrade will be merged and released.

I have enabled edits from maintainers, so feel free to make any changes to this branch! Also, please let me know if you have any questions or concerns and if I can help somehow. Thanks!