### PR TITLE
Add support for Clean and Idris in fenced code blocks

### DIFF
--- a/grammars/fixtures/fenced-code.cson
+++ b/grammars/fixtures/fenced-code.cson
@@ -23,6 +23,7 @@ list: [
   { pattern:'ass' }
   { pattern:'coffee|coffeescript|coffee-script', include:'source.coffee' }
   { pattern:'c' }
+  { pattern:'clean' }
   { pattern:'clojure' }
   { pattern:'cpp|c\\+\\+', include:'source.cpp' }
   { pattern:'cr|crystal', include:'source.crystal'}
@@ -39,6 +40,7 @@ list: [
   { pattern:'go|golang', include:'source.go' }
   { pattern:'haskell' }
   { pattern:'html', include:'text.html.basic' }
+  { pattern:'idris' }
   { pattern:'java' }
   { pattern:'javascript|js|jsx', include:'source.js' }
   { pattern:'json|har', include:'source.json' }


### PR DESCRIPTION
This PR adds support for two functional languages in Markdown's fenced code blocks: [Clean](http://clean.cs.ru.nl) and [Idris](http://www.idris-lang.org). For both languages Atom grammars are available via the package manager.