### PR TITLE
Adhere to "naming convention" for embedded grammars

### DIFF
--- a/grammars/fixtures/fenced-code.cson
+++ b/grammars/fixtures/fenced-code.cson
@@ -13,7 +13,7 @@ scopeName: "fenced-code.md"
 #
 # 'pattern' is required; item is ignored if 'pattern' is missing
 # If 'include' is omitted, 'include' will become 'source.'+pattern
-# If 'contentName' is omitted, 'contentName' will become 'embedded.'+pattern
+# If 'contentName' is omitted, 'contentName' will become pattern+'.embedded'+extension
 
 # NOTE
 # Keep this list alphabetized
@@ -57,9 +57,9 @@ list: [
   # { pattern:'php' }
   # { pattern:'php', contentName:'text.html.php' }
   # { pattern:'php', include:'text.html.php' }
-  # { pattern:'php', include:'text.html.basic', contentName:'embedded.text.html.php' }
+  # { pattern:'php', include:'text.html.basic', contentName:'text.embedded.html.php' }
   # { pattern:'php', include:'text.html.basic' }
-  # { pattern:'php', include:'text.html.php', contentName:'source.js.embedded.html' }
+  # { pattern:'php', include:'text.html.php', contentName:'source.embedded.js.html' }
 
   { pattern:'py|python', include:'source.python' }
   { pattern:'r' }
@@ -80,6 +80,6 @@ list: [
   {
     pattern: '[a-zA-Z0-9-_]+'
     include: 'source'
-    patternName: 'embedded.source'
+    patternName: 'source.embedded'
   }
 ]

--- a/grammars/language-markdown.json
+++ b/grammars/language-markdown.json
@@ -1410,7 +1410,7 @@
           "begin": "(?x) (```)( (\\{)(r)(?:\\s)? (?:([a-zA-Z0-9|_|-]*)(?=[\\s|,|}])\\s?)? ([^\\}]*)? (\\}) )",
           "end": "^(\\1)$",
           "name": "fenced.code.md",
-          "contentName": "embedded.source.r",
+          "contentName": "source.embedded.r",
           "patterns": [
             {
               "include": "source.r"
@@ -2298,7 +2298,7 @@
             }
           },
           "name": "fenced.code.md",
-          "contentName": "embedded.text.html.markdown.source.gfm.apib",
+          "contentName": "text.embedded.html.markdown.source.gfm.apib",
           "patterns": [
             {
               "include": "text.html.markdown.source.gfm.apib"
@@ -2338,7 +2338,7 @@
             }
           },
           "name": "fenced.code.md",
-          "contentName": "embedded.source.ass",
+          "contentName": "source.embedded.ass",
           "patterns": [
             {
               "include": "source.ass"
@@ -2378,7 +2378,7 @@
             }
           },
           "name": "fenced.code.md",
-          "contentName": "embedded.source.coffee",
+          "contentName": "source.embedded.coffee",
           "patterns": [
             {
               "include": "source.coffee"
@@ -2418,7 +2418,7 @@
             }
           },
           "name": "fenced.code.md",
-          "contentName": "embedded.source.c",
+          "contentName": "source.embedded.c",
           "patterns": [
             {
               "include": "source.c"
@@ -2458,7 +2458,7 @@
             }
           },
           "name": "fenced.code.md",
-          "contentName": "embedded.source.clean",
+          "contentName": "source.embedded.clean",
           "patterns": [
             {
               "include": "source.clean"
@@ -2498,7 +2498,7 @@
             }
           },
           "name": "fenced.code.md",
-          "contentName": "embedded.source.clojure",
+          "contentName": "source.embedded.clojure",
           "patterns": [
             {
               "include": "source.clojure"
@@ -2538,7 +2538,7 @@
             }
           },
           "name": "fenced.code.md",
-          "contentName": "embedded.source.cpp",
+          "contentName": "source.embedded.cpp",
           "patterns": [
             {
               "include": "source.cpp"
@@ -2578,7 +2578,7 @@
             }
           },
           "name": "fenced.code.md",
-          "contentName": "embedded.source.crystal",
+          "contentName": "source.embedded.crystal",
           "patterns": [
             {
               "include": "source.crystal"
@@ -2618,7 +2618,7 @@
             }
           },
           "name": "fenced.code.md",
-          "contentName": "embedded.source.cs",
+          "contentName": "source.embedded.cs",
           "patterns": [
             {
               "include": "source.cs"
@@ -2658,7 +2658,7 @@
             }
           },
           "name": "fenced.code.md",
-          "contentName": "embedded.source.css",
+          "contentName": "source.embedded.css",
           "patterns": [
             {
               "include": "source.css"
@@ -2698,7 +2698,7 @@
             }
           },
           "name": "fenced.code.md",
-          "contentName": "embedded.source.diff",
+          "contentName": "source.embedded.diff",
           "patterns": [
             {
               "include": "source.diff"
@@ -2738,7 +2738,7 @@
             }
           },
           "name": "fenced.code.md",
-          "contentName": "embedded.source.elixir",
+          "contentName": "source.embedded.elixir",
           "patterns": [
             {
               "include": "source.elixir"
@@ -2778,7 +2778,7 @@
             }
           },
           "name": "fenced.code.md",
-          "contentName": "embedded.source.elm",
+          "contentName": "source.embedded.elm",
           "patterns": [
             {
               "include": "source.elm"
@@ -2818,7 +2818,7 @@
             }
           },
           "name": "fenced.code.md",
-          "contentName": "embedded.source.erlang",
+          "contentName": "source.embedded.erlang",
           "patterns": [
             {
               "include": "source.erlang"
@@ -2858,7 +2858,7 @@
             }
           },
           "name": "fenced.code.md",
-          "contentName": "embedded.source.go",
+          "contentName": "source.embedded.go",
           "patterns": [
             {
               "include": "source.go"
@@ -2898,7 +2898,7 @@
             }
           },
           "name": "fenced.code.md",
-          "contentName": "embedded.source.haskell",
+          "contentName": "source.embedded.haskell",
           "patterns": [
             {
               "include": "source.haskell"
@@ -2938,7 +2938,7 @@
             }
           },
           "name": "fenced.code.md",
-          "contentName": "embedded.text.html.basic",
+          "contentName": "text.embedded.html.basic",
           "patterns": [
             {
               "include": "text.html.basic"
@@ -2978,7 +2978,7 @@
             }
           },
           "name": "fenced.code.md",
-          "contentName": "embedded.source.idris",
+          "contentName": "source.embedded.idris",
           "patterns": [
             {
               "include": "source.idris"
@@ -3018,7 +3018,7 @@
             }
           },
           "name": "fenced.code.md",
-          "contentName": "embedded.source.java",
+          "contentName": "source.embedded.java",
           "patterns": [
             {
               "include": "source.java"
@@ -3058,7 +3058,7 @@
             }
           },
           "name": "fenced.code.md",
-          "contentName": "embedded.source.js",
+          "contentName": "source.embedded.js",
           "patterns": [
             {
               "include": "source.js"
@@ -3098,7 +3098,7 @@
             }
           },
           "name": "fenced.code.md",
-          "contentName": "embedded.source.json",
+          "contentName": "source.embedded.json",
           "patterns": [
             {
               "include": "source.json"
@@ -3138,7 +3138,7 @@
             }
           },
           "name": "fenced.code.md",
-          "contentName": "embedded.source.julia",
+          "contentName": "source.embedded.julia",
           "patterns": [
             {
               "include": "source.julia"
@@ -3178,7 +3178,7 @@
             }
           },
           "name": "fenced.code.md",
-          "contentName": "embedded.text.tex.latex",
+          "contentName": "text.embedded.tex.latex",
           "patterns": [
             {
               "include": "text.tex.latex"
@@ -3218,7 +3218,7 @@
             }
           },
           "name": "fenced.code.md",
-          "contentName": "embedded.source.css.less",
+          "contentName": "source.embedded.css.less",
           "patterns": [
             {
               "include": "source.css.less"
@@ -3258,7 +3258,7 @@
             }
           },
           "name": "fenced.code.md",
-          "contentName": "embedded.source.lua",
+          "contentName": "source.embedded.lua",
           "patterns": [
             {
               "include": "source.lua"
@@ -3298,7 +3298,7 @@
             }
           },
           "name": "fenced.code.md",
-          "contentName": "embedded.text.md",
+          "contentName": "text.embedded.md",
           "patterns": [
             {
               "include": "text.md"
@@ -3338,7 +3338,7 @@
             }
           },
           "name": "fenced.code.md",
-          "contentName": "embedded.source.mathematica",
+          "contentName": "source.embedded.mathematica",
           "patterns": [
             {
               "include": "source.mathematica"
@@ -3378,7 +3378,7 @@
             }
           },
           "name": "fenced.code.md",
-          "contentName": "embedded.source.mermaid",
+          "contentName": "source.embedded.mermaid",
           "patterns": [
             {
               "include": "source.mermaid"
@@ -3418,7 +3418,7 @@
             }
           },
           "name": "fenced.code.md",
-          "contentName": "embedded.text.html.markdown.source.gfm.mson",
+          "contentName": "text.embedded.html.markdown.source.gfm.mson",
           "patterns": [
             {
               "include": "text.html.markdown.source.gfm.mson"
@@ -3458,7 +3458,7 @@
             }
           },
           "name": "fenced.code.md",
-          "contentName": "embedded.source.objc",
+          "contentName": "source.embedded.objc",
           "patterns": [
             {
               "include": "source.objc"
@@ -3498,7 +3498,7 @@
             }
           },
           "name": "fenced.code.md",
-          "contentName": "embedded.source.python",
+          "contentName": "source.embedded.python",
           "patterns": [
             {
               "include": "source.python"
@@ -3538,7 +3538,7 @@
             }
           },
           "name": "fenced.code.md",
-          "contentName": "embedded.source.r",
+          "contentName": "source.embedded.r",
           "patterns": [
             {
               "include": "source.r"
@@ -3578,7 +3578,7 @@
             }
           },
           "name": "fenced.code.md",
-          "contentName": "embedded.source.ruby",
+          "contentName": "source.embedded.ruby",
           "patterns": [
             {
               "include": "source.ruby"
@@ -3618,7 +3618,7 @@
             }
           },
           "name": "fenced.code.md",
-          "contentName": "embedded.source.rust",
+          "contentName": "source.embedded.rust",
           "patterns": [
             {
               "include": "source.rust"
@@ -3658,7 +3658,7 @@
             }
           },
           "name": "fenced.code.md",
-          "contentName": "embedded.source.sass",
+          "contentName": "source.embedded.sass",
           "patterns": [
             {
               "include": "source.sass"
@@ -3698,7 +3698,7 @@
             }
           },
           "name": "fenced.code.md",
-          "contentName": "embedded.source.css.scss",
+          "contentName": "source.embedded.css.scss",
           "patterns": [
             {
               "include": "source.css.scss"
@@ -3738,7 +3738,7 @@
             }
           },
           "name": "fenced.code.md",
-          "contentName": "embedded.source.shell",
+          "contentName": "source.embedded.shell",
           "patterns": [
             {
               "include": "source.shell"
@@ -3778,7 +3778,7 @@
             }
           },
           "name": "fenced.code.md",
-          "contentName": "embedded.source.sql",
+          "contentName": "source.embedded.sql",
           "patterns": [
             {
               "include": "source.sql"
@@ -3818,7 +3818,7 @@
             }
           },
           "name": "fenced.code.md",
-          "contentName": "embedded.source.swift",
+          "contentName": "source.embedded.swift",
           "patterns": [
             {
               "include": "source.swift"
@@ -3858,7 +3858,7 @@
             }
           },
           "name": "fenced.code.md",
-          "contentName": "embedded.text.xml",
+          "contentName": "text.embedded.xml",
           "patterns": [
             {
               "include": "text.xml"
@@ -3898,7 +3898,7 @@
             }
           },
           "name": "fenced.code.md",
-          "contentName": "embedded.source",
+          "contentName": "source.embedded",
           "patterns": [
             {
               "include": "source"

--- a/grammars/repositories/flavors/rmarkdown.cson
+++ b/grammars/repositories/flavors/rmarkdown.cson
@@ -16,7 +16,7 @@ patterns: [
     end: '^(\\1)$'
 
     name: 'fenced.code.md'
-    contentName: 'embedded.source.r'
+    contentName: 'source.embedded.r'
     patterns: [{ include: 'source.r' }]
 
     beginCaptures:

--- a/spec/fixtures/blocks/fenced-code.ass
+++ b/spec/fixtures/blocks/fenced-code.ass
@@ -269,7 +269,7 @@
       "```": punctuation.md
       "ruby": language.constant.md
       ""
-      embedded.source.ruby {
+      source.embedded.ruby {
         "def foo(x)"
         "  return 3"
         "end"
@@ -299,7 +299,7 @@
         }
       }
       " $%@#$"
-      embedded.source.ruby {
+      source.embedded.ruby {
         "def foo(x)"
         "  return 3"
         "end"
@@ -352,7 +352,7 @@
 #       "{": punctuation.md
 #       ".js": language.constant.md
 #       "}": punctuation.md
-#       embedded.source.js {
+#       source.embedded.js {
 #         "let answer = 42"
 #       }
 #       "~~~~": punctuation.md
@@ -376,7 +376,7 @@
 #       "{": punctuation.md
 #       "js": language.constant.md
 #       "}": punctuation.md
-#       embedded.source.js {
+#       source.embedded.js {
 #         "let answer = 42"
 #       }
 #       "~~~~": punctuation.md
@@ -399,7 +399,7 @@
       "~~~~": punctuation.md
       "js": language.constant.md
       ""
-      embedded.source.js {
+      source.embedded.js {
         "let answer = 42"
       }
       "~~~~": punctuation.md
@@ -423,7 +423,7 @@
       " "
       "js": language.constant.md
       ""
-      embedded.source.js {
+      source.embedded.js {
         "let answer = 42"
       }
       "~~~~": punctuation.md
@@ -449,7 +449,7 @@
       ".js": language.constant.md
       " "
       "}": punctuation.md
-      embedded.source.js {
+      source.embedded.js {
         "let answer = 42"
       }
       "~~~~": punctuation.md
@@ -474,7 +474,7 @@
       "js": language.constant.md
       " "
       "}": punctuation.md
-      embedded.source.js {
+      source.embedded.js {
         "let answer = 42"
       }
       "~~~~": punctuation.md
@@ -498,7 +498,7 @@
 #       "{": punctuation.md
 #       ".unknownscript": language.constant.md
 #       "}": punctuation.md
-#       embedded.source {
+#       source.embedded {
 #         "let answer = 42"
 #       }
 #       "~~~~": punctuation.md
@@ -522,7 +522,7 @@
 #       "{": punctuation.md
 #       "unknownscript": language.constant.md
 #       "}": punctuation.md
-#       embedded.source {
+#       source.embedded {
 #         "let answer = 42"
 #       }
 #       "~~~~": punctuation.md
@@ -545,7 +545,7 @@
       "~~~~": punctuation.md
       "unknownscript": language.constant.md
       ""
-      embedded.source {
+      source.embedded {
         "let answer = 42"
       }
       "~~~~": punctuation.md
@@ -569,7 +569,7 @@
       " "
       "unknownscript": language.constant.md
       ""
-      embedded.source {
+      source.embedded {
         "let answer = 42"
       }
       "~~~~": punctuation.md
@@ -594,7 +594,7 @@
       ".unknownscript": language.constant.md
       " "
       "}": punctuation.md
-      embedded.source {
+      source.embedded {
         "let answer = 42"
       }
       "~~~~": punctuation.md
@@ -619,7 +619,7 @@
       "unknownscript": language.constant.md
       " "
       "}": punctuation.md
-      embedded.source {
+      source.embedded {
         "let answer = 42"
       }
       "~~~~": punctuation.md
@@ -642,7 +642,7 @@
 #     "let answer = 42"
 #     fenced.code.md {
 #       "~~~~": punctuation.md
-#       embedded.source {
+#       source.embedded {
 #         "> Quote"
 #       }
 #     }
@@ -659,7 +659,7 @@
 #     "let answer = 42"
 #     fenced.code.md {
 #       "~~~~": punctuation.md
-#       embedded.source {
+#       source.embedded {
 #         "> Quote"
 #       }
 #     }

--- a/spec/fixtures/flavors/markdown-extra.ass
+++ b/spec/fixtures/flavors/markdown-extra.ass
@@ -276,7 +276,7 @@
         }
       }
       "}": punctuation.md
-      embedded.source.js {
+      source.embedded.js {
         "alert("Hello world");"
       }
       "~~~~~~~~~~~~~~~~~~~~~~~~~~~~": punctuation.md

--- a/spec/fixtures/flavors/rmarkdown.ass
+++ b/spec/fixtures/flavors/rmarkdown.ass
@@ -8,7 +8,7 @@
       "{": punctuation.md
       "r": language.constant.md
       "}": punctuation.md
-      "summary(cars)": embedded.source.r
+      "summary(cars)": source.embedded.r
       "```": punctuation.md
     }
   }
@@ -235,7 +235,7 @@
 #         }
 #       }
 #       "}": punctuation.md
-#       "#include <Rcpp.h>": embedded.source.r
+#       "#include <Rcpp.h>": source.embedded.r
 #       "```": punctuation.md
 #     }
 #   }

--- a/spec/fixtures/issues.ass
+++ b/spec/fixtures/issues.ass
@@ -269,7 +269,7 @@
       "```": punctuation.md
       "nohighlight": language.constant.md
       ""
-      embedded.source {
+      source.embedded {
         "first block"
       }
       "```": punctuation.md
@@ -304,7 +304,7 @@
       "```": punctuation.md
       "nohighlight": language.constant.md
       ""
-      embedded.source {
+      source.embedded {
         "second block"
       }
       "```": punctuation.md
@@ -335,7 +335,7 @@
       "```": punctuation.md
       "js": language.constant.md
       ""
-      embedded.source.js {
+      source.embedded.js {
         "var test = "String";"
       }
       "```": punctuation.md
@@ -363,7 +363,7 @@
       "```": punctuation.md
       "js": language.constant.md
       ""
-      embedded.source.js {
+      source.embedded.js {
         "var sum = 12 + 34;"
       }
       "```": punctuation.md
@@ -386,7 +386,7 @@
       "```": punctuation.md
       "lua": language.constant.md
       ""
-      embedded.source.lua {
+      source.embedded.lua {
         "function(progress, start, delta)"
         "  return start + (progress * delta)"
         "end"


### PR DESCRIPTION
Other language packages, like [gfm](https://github.com/atom/language-gfm/blob/master/grammars/gfm.cson#L873), [reStructuredText](https://github.com/Lukasa/language-restructuredtext/blob/master/grammars/restructuredtext.cson#L695), [asciidoc](https://github.com/asciidoctor/atom-language-asciidoc/blob/master/grammars/language-asciidoc.cson#L4101) or [knitr](https://github.com/christophergandrud/language-knitr/blob/master/grammars/knitr.cson#L54) use the convention `source.embedded.language` for embedded languages.

In [Hydrogen](https://github.com/nteract/hydrogen/) we use this behavior to allow users to execute a code block interactively (see https://github.com/nteract/hydrogen/pull/637).

It would be great if `language-markdown` would adhere to this standard so we can support it as well.

Here is a example of how this looks with `language-markdown`:
![markdown](https://cloud.githubusercontent.com/assets/13285808/24314427/d5285978-10e1-11e7-83f1-47e7535ef267.gif)