### PR TITLE
Add embedded code variation support

### DIFF
--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -71,6 +71,18 @@ a------
 $something = true;
 ``````
 
+``` php
+<html <?php echo "I am in an HTML tag!"; ?> />
+
+<?php
+class Hello {
+  function world() {
+    echo "Do some stuff and things in PHP...";
+  }
+}
+?>
+```
+
 ``` javascript
 var object = {
   init: function () {
@@ -92,7 +104,6 @@ def foo(x)
 end
 ~~~~~~~
 
-<!--
 ~~~ erb
 <% wrap_layout :layout do %>
   <article>
@@ -100,7 +111,6 @@ end
   </article>
 <% end %>
 ~~~
--->
 
 
 

--- a/grammars/fixtures/fenced-code.cson
+++ b/grammars/fixtures/fenced-code.cson
@@ -53,14 +53,7 @@ list: [
   { pattern:'mermaid' }
   { pattern:'mson', include:'text.html.markdown.source.gfm.mson' }
   { pattern:'objc|objective-c', include:'source.objc' }
-
-  # { pattern:'php' }
-  # { pattern:'php', contentName:'text.html.php' }
-  # { pattern:'php', include:'text.html.php' }
-  # { pattern:'php', include:'text.html.basic', contentName:'embedded.text.html.php' }
-  # { pattern:'php', include:'text.html.basic' }
-  # { pattern:'php', include:'text.html.php', contentName:'source.js.embedded.html' }
-
+  { pattern:'php', include:'text.html.php' }
   { pattern:'py|python', include:'source.python' }
   { pattern:'r' }
   { pattern:'ruby' }

--- a/grammars/injections/php.cson
+++ b/grammars/injections/php.cson
@@ -1,0 +1,92 @@
+key: 'embedded.text.html.php - (meta.embedded | meta.tag), L:embedded.text.html.php meta.tag, L:embedded.source.js.embedded.html'
+patterns: [
+  {
+    begin: '(^\\s*)(?=<\\?(?![^?]*\\?>))'
+    beginCaptures:
+      0:
+        name: 'punctuation.whitespace.embedded.leading.php'
+    end: '(?!\\G)(\\s*$\\n)?'
+    endCaptures:
+      0:
+        name: 'punctuation.whitespace.embedded.trailing.php'
+    patterns: [
+      {
+        begin: '<\\?(?i:php|=)?'
+        beginCaptures:
+          0:
+            name: 'punctuation.section.embedded.begin.php'
+        contentName: 'source.php'
+        end: '(\\?)>'
+        endCaptures:
+          0:
+            name: 'punctuation.section.embedded.end.php'
+          1:
+            name: 'source.php'
+        name: 'meta.embedded.block.php'
+        patterns: [
+          {
+            include: 'text.html.php#language'
+          }
+        ]
+      }
+    ]
+  }
+  {
+    begin: '<\\?(?i:php|=)?(?![^?]*\\?>)'
+    beginCaptures:
+      0:
+        name: 'punctuation.section.embedded.begin.php'
+    contentName: 'source.php'
+    end: '(\\G)>'
+    endCaptures:
+      0:
+        name: 'punctuation.section.embedded.end.php'
+      1:
+        name: 'source.php'
+    name: 'meta.embedded.block.php'
+    patterns: [
+      {
+        include: 'text.html.php#language'
+      }
+    ]
+  }
+  {
+    begin: '<\\?(?i:php|=)?'
+    beginCaptures:
+      0:
+        name: 'punctuation.section.embedded.begin.php'
+    end: '>'
+    endCaptures:
+      0:
+        name: 'punctuation.section.embedded.end.php'
+    name: 'meta.embedded.line.php'
+    patterns: [
+      {
+        captures:
+          1:
+            name: 'source.php'
+          2:
+            name: 'punctuation.section.embedded.end.php'
+          3:
+            name: 'source.php'
+        match: '\\G(\\s*)((\\?))(?=>)'
+        name: 'meta.special.empty-tag.php'
+      }
+      {
+        begin: '\\G'
+        contentName: 'source.php'
+        end: '(\\?)(?=>)'
+        endCaptures:
+          0:
+            name: 'punctuation.section.embedded.end.php'
+          1:
+            name: 'source.php'
+        patterns: [
+          {
+            include: 'text.html.php#language'
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/grammars/language-markdown.json
+++ b/grammars/language-markdown.json
@@ -2786,6 +2786,46 @@
           ]
         },
         {
+          "begin": "^\\s*([`~]{3,})\\s*(\\{?)((?:\\.?)(?:erb))(?=( |$|{))\\s*(\\{?)([^`\\{\\}]*)(\\}?)$",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.md"
+            },
+            "2": {
+              "name": "punctuation.md"
+            },
+            "3": {
+              "name": "language.constant.md"
+            },
+            "5": {
+              "name": "punctuation.md"
+            },
+            "6": {
+              "patterns": [
+                {
+                  "include": "#special-attribute-elements"
+                }
+              ]
+            },
+            "7": {
+              "name": "punctuation.md"
+            }
+          },
+          "end": "^\\s*(\\1)$",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.md"
+            }
+          },
+          "name": "fenced.code.md",
+          "contentName": "embedded.text.html.erb",
+          "patterns": [
+            {
+              "include": "text.html.erb"
+            }
+          ]
+        },
+        {
           "begin": "^\\s*([`~]{3,})\\s*(\\{?)((?:\\.?)(?:erlang))(?=( |$|{))\\s*(\\{?)([^`\\{\\}]*)(\\}?)$",
           "beginCaptures": {
             "1": {
@@ -3466,6 +3506,46 @@
           ]
         },
         {
+          "begin": "^\\s*([`~]{3,})\\s*(\\{?)((?:\\.?)(?:php))(?=( |$|{))\\s*(\\{?)([^`\\{\\}]*)(\\}?)$",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.md"
+            },
+            "2": {
+              "name": "punctuation.md"
+            },
+            "3": {
+              "name": "language.constant.md"
+            },
+            "5": {
+              "name": "punctuation.md"
+            },
+            "6": {
+              "patterns": [
+                {
+                  "include": "#special-attribute-elements"
+                }
+              ]
+            },
+            "7": {
+              "name": "punctuation.md"
+            }
+          },
+          "end": "^\\s*(\\1)$",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.md"
+            }
+          },
+          "name": "fenced.code.md",
+          "contentName": "embedded.text.html.php",
+          "patterns": [
+            {
+              "include": "text.html.php"
+            }
+          ]
+        },
+        {
           "begin": "^\\s*([`~]{3,})\\s*(\\{?)((?:\\.?)(?:py|python))(?=( |$|{))\\s*(\\{?)([^`\\{\\}]*)(\\}?)$",
           "beginCaptures": {
             "1": {
@@ -3902,6 +3982,168 @@
           "patterns": [
             {
               "include": "source"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "injections": {
+    "embedded.text.html.erb - (meta.embedded.block.erb | meta.embedded.line.erb | meta.tag | comment), meta.tag string.quoted": {
+      "patterns": [
+        {
+          "begin": "(^\\s*)(?=<%+#(?![^%]*%>))",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.whitespace.comment.leading.erb"
+            }
+          },
+          "end": "(?!\\G)(\\s*$\\n)?",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.whitespace.comment.trailing.erb"
+            }
+          },
+          "patterns": [
+            {
+              "include": "text.html.erb#comment"
+            }
+          ]
+        },
+        {
+          "begin": "(^\\s*)(?=<%(?![^%]*%>))",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.whitespace.embedded.leading.erb"
+            }
+          },
+          "end": "(?!\\G)(\\s*$\\n)?",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.whitespace.embedded.trailing.erb"
+            }
+          },
+          "patterns": [
+            {
+              "include": "text.html.erb#tags"
+            }
+          ]
+        }
+      ]
+    },
+    "embedded.text.html.php - (meta.embedded | meta.tag), L:embedded.text.html.php meta.tag, L:embedded.source.js.embedded.html": {
+      "patterns": [
+        {
+          "begin": "(^\\s*)(?=<\\?(?![^?]*\\?>))",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.whitespace.embedded.leading.php"
+            }
+          },
+          "end": "(?!\\G)(\\s*$\\n)?",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.whitespace.embedded.trailing.php"
+            }
+          },
+          "patterns": [
+            {
+              "begin": "<\\?(?i:php|=)?",
+              "beginCaptures": {
+                "0": {
+                  "name": "punctuation.section.embedded.begin.php"
+                }
+              },
+              "contentName": "source.php",
+              "end": "(\\?)>",
+              "endCaptures": {
+                "0": {
+                  "name": "punctuation.section.embedded.end.php"
+                },
+                "1": {
+                  "name": "source.php"
+                }
+              },
+              "name": "meta.embedded.block.php",
+              "patterns": [
+                {
+                  "include": "text.html.php#language"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "begin": "<\\?(?i:php|=)?(?![^?]*\\?>)",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.section.embedded.begin.php"
+            }
+          },
+          "contentName": "source.php",
+          "end": "(\\G)>",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.section.embedded.end.php"
+            },
+            "1": {
+              "name": "source.php"
+            }
+          },
+          "name": "meta.embedded.block.php",
+          "patterns": [
+            {
+              "include": "text.html.php#language"
+            }
+          ]
+        },
+        {
+          "begin": "<\\?(?i:php|=)?",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.section.embedded.begin.php"
+            }
+          },
+          "end": ">",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.section.embedded.end.php"
+            }
+          },
+          "name": "meta.embedded.line.php",
+          "patterns": [
+            {
+              "captures": {
+                "1": {
+                  "name": "source.php"
+                },
+                "2": {
+                  "name": "punctuation.section.embedded.end.php"
+                },
+                "3": {
+                  "name": "source.php"
+                }
+              },
+              "match": "\\G(\\s*)((\\?))(?=>)",
+              "name": "meta.special.empty-tag.php"
+            },
+            {
+              "begin": "\\G",
+              "contentName": "source.php",
+              "end": "(\\?)(?=>)",
+              "endCaptures": {
+                "0": {
+                  "name": "punctuation.section.embedded.end.php"
+                },
+                "1": {
+                  "name": "source.php"
+                }
+              },
+              "patterns": [
+                {
+                  "include": "text.html.php#language"
+                }
+              ]
             }
           ]
         }

--- a/lib/GrammarCompiler.js
+++ b/lib/GrammarCompiler.js
@@ -21,6 +21,8 @@ module.exports = class GrammarCompiler {
     const inputPath = path.join(__dirname, input)
     const grammar = CSON.readFileSync(inputPath)
 
+    grammar.injections = this.compileInjectionsGrammar()
+
     for (let i = 0; i < directories.length; i++) {
       const directoryPath = path.join(__dirname, '../grammars/repositories/' + directories[i])
       const directory = new Directory(directoryPath)
@@ -52,6 +54,29 @@ module.exports = class GrammarCompiler {
     const inputPath = path.join(__dirname, input)
     const data = CSON.readFileSync(inputPath)
     return this.createPatternsFromData(data)
+  }
+
+  // Reads fixtures from {input},
+  // parses {data} to expand shortened syntax,
+  // creates and returns patterns from valid items in {data}.
+  compileInjectionsGrammar () {
+    const directoryPath = path.join(__dirname, '../grammars/injections')
+    const directory = new Directory(directoryPath)
+    const entries = directory.getEntriesSync()
+    const injections = {}
+
+    for (let j = 0; j < entries.length; j++) {
+      const entry = entries[j];
+      const { key, patterns } = CSON.readFileSync(entry.path)
+
+      if (key && patterns) {
+        injections[key] = {
+          patterns: patterns
+        }
+      }
+    }
+
+    return injections
   }
 
   // Transform an {item} into a {pattern} object,


### PR DESCRIPTION
## Description

This PR adds support for the embedded code variations discussed in #77 (and adds proper support for PHP as an example).

## Background

The `atom/first-mate` package has an issue with extending injected grammars (see atom/first-mate#40) that prevents the injected patterns from being included in the extension. As an example, the PHP grammar is an extension of `text.html.basic` with the PHP tags and syntax injected into the `text.html.php` grammar. When extending `text.html.grammar`, the injections are dropped, and only the `text.html.basic` patterns are included.

## Details

To accomplish adding injected grammars, take note of the `grammars/injections/php.cson` file. The injections from the [atom/language-php](https://github.com/atom/language-php/blob/master/grammars/php.cson) grammar have been imported and modified to ensure that `text.html.php` is extended properly.

![screenshot 2017-03-24 21 52 49](https://cloud.githubusercontent.com/assets/920019/24319277/4e8afb82-10dc-11e7-97ce-d6ba54aaa307.png)