### PR TITLE
Add math-block notation

### DIFF
--- a/grammars/language-markdown.json
+++ b/grammars/language-markdown.json
@@ -1159,7 +1159,7 @@
         {
           "name": "block.math.markup.md",
           "begin": "(\\${2})",
-          "end": "(\\${2})(?:.*)",
+          "end": "(\\${2})",
           "patterns": [
             {
               "include": "text.tex.latex"

--- a/grammars/language-markdown.json
+++ b/grammars/language-markdown.json
@@ -1175,6 +1175,46 @@
               "name": "punctuation.md"
             }
           }
+        },
+        {
+          "name": "block.math.markup.md",
+          "begin": "\\\\\\[",
+          "end": "\\\\\\]",
+          "patterns": [
+            {
+              "include": "text.tex.latex"
+            }
+          ],
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.md"
+            }
+          },
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.md"
+            }
+          }
+        },
+        {
+          "name": "block.math.markup.md",
+          "begin": "\\\\begin\\{(equation\\*?)\\}",
+          "end": "\\\\end\\{\\1\\}",
+          "patterns": [
+            {
+              "include": "text.tex.latex"
+            }
+          ],
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.md"
+            }
+          },
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.md"
+            }
+          }
         }
       ]
     },

--- a/grammars/language-markdown.json
+++ b/grammars/language-markdown.json
@@ -1178,8 +1178,8 @@
         },
         {
           "name": "block.math.markup.md",
-          "begin": "\\\\\\\\\\[",
-          "end": "\\\\\\\\\\]",
+          "begin": "(?:\\\\)?\\\\\\[",
+          "end": "(?:\\\\)?\\\\\\]",
           "patterns": [
             {
               "include": "text.tex.latex"

--- a/grammars/language-markdown.json
+++ b/grammars/language-markdown.json
@@ -1198,7 +1198,7 @@
         },
         {
           "name": "block.math.markup.md",
-          "begin": "(\\\\begin)(\\{)(equation\\*?)(\\})",
+          "begin": "(\\\\begin)(\\{)((?:align|equation|multline|split|gather)\\*?)(\\})",
           "end": "(\\\\end)(\\{)(\\3)(\\})",
           "patterns": [
             {

--- a/grammars/language-markdown.json
+++ b/grammars/language-markdown.json
@@ -1178,8 +1178,8 @@
         },
         {
           "name": "block.math.markup.md",
-          "begin": "(?<=^|\\s|>)\\\\\\[(?=\\s|\\\\\\w)",
-          "end": "(?<=^|\\s|\\})\\\\\\](?=\\s|</)",
+          "begin": "\\\\\\\\\\[",
+          "end": "\\\\\\\\\\]",
           "patterns": [
             {
               "include": "text.tex.latex"

--- a/grammars/language-markdown.json
+++ b/grammars/language-markdown.json
@@ -1178,28 +1178,28 @@
         },
         {
           "name": "block.math.markup.md",
-          "begin": "\\\\\\[",
-          "end": "\\\\\\]",
+          "begin": "(?<=^|\\s|>)\\\\\\[(?=\\s|\\\\\\w)",
+          "end": "(?<=^|\\s|\\})\\\\\\](?=\\s|</)",
           "patterns": [
             {
               "include": "text.tex.latex"
             }
           ],
           "beginCaptures": {
-            "1": {
-              "name": "punctuation.md"
+            "0": {
+              "name": "punctuation.definition.string.begin.latex"
             }
           },
           "endCaptures": {
-            "1": {
-              "name": "punctuation.md"
+            "0": {
+              "name": "punctuation.definition.string.end.latex"
             }
           }
         },
         {
           "name": "block.math.markup.md",
-          "begin": "\\\\begin\\{(equation\\*?)\\}",
-          "end": "\\\\end\\{\\1\\}",
+          "begin": "(\\\\begin)(\\{)(equation\\*?)(\\})",
+          "end": "(\\\\end)(\\{)(\\3)(\\})",
           "patterns": [
             {
               "include": "text.tex.latex"
@@ -1207,12 +1207,30 @@
           ],
           "beginCaptures": {
             "1": {
-              "name": "punctuation.md"
+              "name": "support.function.be.latex"
+            },
+            "2": {
+              "name": "punctuation.definition.arguments.begin.latex"
+            },
+            "3": {
+              "name": "variable.parameter.function.latex"
+            },
+            "4": {
+              "name": "punctuation.definition.arguments.end.latex"
             }
           },
           "endCaptures": {
             "1": {
-              "name": "punctuation.md"
+              "name": "support.function.be.latex"
+            },
+            "2": {
+              "name": "punctuation.definition.arguments.begin.latex"
+            },
+            "3": {
+              "name": "variable.parameter.function.latex"
+            },
+            "4": {
+              "name": "punctuation.definition.arguments.end.latex"
             }
           }
         }

--- a/grammars/repositories/flavors/math-block.cson
+++ b/grammars/repositories/flavors/math-block.cson
@@ -1,13 +1,35 @@
 key: 'math-block'
 patterns: [
+  {
+    name: 'block.math.markup.md'
+    begin: '(\\${2})'
+    end: '(\\${2})(?:.*)'
+    patterns: [{ include: 'text.tex.latex' }]
+    beginCaptures:
+      1: name: 'punctuation.md'
+    endCaptures:
+      1: name: 'punctuation.md'
+  }
 
-  name: 'block.math.markup.md'
-  begin: '(\\${2})'
-  end: '(\\${2})(?:.*)'
-  patterns: [{ include: 'text.tex.latex' }]
-  beginCaptures:
-    1: name: 'punctuation.md'
-  endCaptures:
-    1: name: 'punctuation.md'
+  {
+    name: 'block.math.markup.md'
+    begin: '\\\\\\['
+    end: '\\\\\\]'
+    patterns: [{ include: 'text.tex.latex' }]
+    beginCaptures:
+      1: name: 'punctuation.md'
+    endCaptures:
+      1: name: 'punctuation.md'
+  }
 
+  {
+    name: 'block.math.markup.md'
+    begin: '\\\\begin\\{(equation\\*?)\\}'
+    end: '\\\\end\\{\\1\\}'
+    patterns: [{ include: 'text.tex.latex' }]
+    beginCaptures:
+      1: name: 'punctuation.md'
+    endCaptures:
+      1: name: 'punctuation.md'
+  }
 ]

--- a/grammars/repositories/flavors/math-block.cson
+++ b/grammars/repositories/flavors/math-block.cson
@@ -13,8 +13,8 @@ patterns: [
 
   {
     name: 'block.math.markup.md'
-    begin: '(?<=^|\\s|>)\\\\\\[(?=\\s|\\\\\\w)'
-    end: '(?<=^|\\s|\\})\\\\\\](?=\\s|</)'
+    begin: '\\\\\\\\\\['
+    end: '\\\\\\\\\\]'
     patterns: [{ include: 'text.tex.latex' }]
     beginCaptures:
       0: name: 'punctuation.definition.string.begin.latex'

--- a/grammars/repositories/flavors/math-block.cson
+++ b/grammars/repositories/flavors/math-block.cson
@@ -3,7 +3,7 @@ patterns: [
   {
     name: 'block.math.markup.md'
     begin: '(\\${2})'
-    end: '(\\${2})(?:.*)'
+    end: '(\\${2})'
     patterns: [{ include: 'text.tex.latex' }]
     beginCaptures:
       1: name: 'punctuation.md'

--- a/grammars/repositories/flavors/math-block.cson
+++ b/grammars/repositories/flavors/math-block.cson
@@ -13,8 +13,8 @@ patterns: [
 
   {
     name: 'block.math.markup.md'
-    begin: '\\\\\\\\\\['
-    end: '\\\\\\\\\\]'
+    begin: '(?:\\\\)?\\\\\\['
+    end: '(?:\\\\)?\\\\\\]'
     patterns: [{ include: 'text.tex.latex' }]
     beginCaptures:
       0: name: 'punctuation.definition.string.begin.latex'

--- a/grammars/repositories/flavors/math-block.cson
+++ b/grammars/repositories/flavors/math-block.cson
@@ -24,7 +24,7 @@ patterns: [
 
   {
     name: 'block.math.markup.md'
-    begin: '(\\\\begin)(\\{)(equation\\*?)(\\})'
+    begin: '(\\\\begin)(\\{)((?:align|equation|multline|split|gather)\\*?)(\\})'
     end: '(\\\\end)(\\{)(\\3)(\\})'
     patterns: [{ include: 'text.tex.latex' }]
     beginCaptures:

--- a/grammars/repositories/flavors/math-block.cson
+++ b/grammars/repositories/flavors/math-block.cson
@@ -13,23 +13,29 @@ patterns: [
 
   {
     name: 'block.math.markup.md'
-    begin: '\\\\\\['
-    end: '\\\\\\]'
+    begin: '(?<=^|\\s|>)\\\\\\[(?=\\s|\\\\\\w)'
+    end: '(?<=^|\\s|\\})\\\\\\](?=\\s|</)'
     patterns: [{ include: 'text.tex.latex' }]
     beginCaptures:
-      1: name: 'punctuation.md'
+      0: name: 'punctuation.definition.string.begin.latex'
     endCaptures:
-      1: name: 'punctuation.md'
+      0: name: 'punctuation.definition.string.end.latex'
   }
 
   {
     name: 'block.math.markup.md'
-    begin: '\\\\begin\\{(equation\\*?)\\}'
-    end: '\\\\end\\{\\1\\}'
+    begin: '(\\\\begin)(\\{)(equation\\*?)(\\})'
+    end: '(\\\\end)(\\{)(\\3)(\\})'
     patterns: [{ include: 'text.tex.latex' }]
     beginCaptures:
-      1: name: 'punctuation.md'
+      1: name: 'support.function.be.latex'
+      2: name: 'punctuation.definition.arguments.begin.latex'
+      3: name: 'variable.parameter.function.latex'
+      4: name: 'punctuation.definition.arguments.end.latex'
     endCaptures:
-      1: name: 'punctuation.md'
+      1: name: 'support.function.be.latex'
+      2: name: 'punctuation.definition.arguments.begin.latex'
+      3: name: 'variable.parameter.function.latex'
+      4: name: 'punctuation.definition.arguments.end.latex'
   }
 ]

--- a/spec/fixtures/flavors/math.ass
+++ b/spec/fixtures/flavors/math.ass
@@ -104,6 +104,28 @@
   }
 }
 
+@math/3a-1
+"An equation needs \[one more backslash\]" {
+  text.md {
+    "An equation needs "
+    "\[": escape.constant.md
+    "one more backslash"
+    "\]": escape.constant.md
+  }
+}
+
+@math/3a-2
+"An equation needs \\\[one less backslash\\\]" {
+  text.md {
+    "An equation needs "
+    "\\": escape.constant.md
+    "\[": escape.constant.md
+    "one less backslash"
+    "\\": escape.constant.md
+    "\]": escape.constant.md
+  }
+}
+
 @math/3b
 "This is a `$variable`" {
   text.md {
@@ -112,6 +134,34 @@
       code.raw.markup.md {
         '`': punctuation.md
         '$variable'
+        '`': punctuation.md
+      }
+    }
+  }
+}
+
+@math/3b-1
+"This is an `\\[inline code\\]`" {
+  text.md {
+    "This is an "
+    "`\\[not an equation\\]`" {
+      code.raw.markup.md {
+        '`': punctuation.md
+        '\\[inline code\\]'
+        '`': punctuation.md
+      }
+    }
+  }
+}
+
+@math/3b-2
+"This is an `\begin{equation} inline code`" {
+  text.md {
+    "This is an "
+    "`\\[not an equation\\]`" {
+      code.raw.markup.md {
+        '`': punctuation.md
+        '\begin{equation} inline code'
         '`': punctuation.md
       }
     }

--- a/spec/fixtures/flavors/math.ass
+++ b/spec/fixtures/flavors/math.ass
@@ -26,6 +26,38 @@
   }
 }
 
+@math/2a-1
+"\\["+
+"f \in \{0,1\}^*\to\{0,1\}^*"+
+"\\]" {
+  text.md {
+    block.math.markup.md {
+      "\\[": punctuation.definition.string.begin.latex
+      "f \in \{0,1\}^*\to\{0,1\}^*"
+      "\\]": punctuation.definition.string.end.latex
+    }
+  }
+}
+
+@math/2a-2
+"\begin{equation}"+
+"f \in \{0,1\}^*\to\{0,1\}^*"+
+"\end{equation}" {
+  text.md {
+    block.math.markup.md {
+      "\begin": support.function.be.latex
+      "{": punctuation.definition.arguments.begin.latex
+      "equation": variable.parameter.function.latex
+      "}": punctuation.definition.arguments.end.latex
+      "f \in \{0,1\}^*\to\{0,1\}^*"
+      "\end": support.function.be.latex
+      "{": punctuation.definition.arguments.begin.latex
+      "equation": variable.parameter.function.latex
+      "}": punctuation.definition.arguments.end.latex
+    }
+  }
+}
+
 @math/2b
 "$$f \in \{0,1\}^*\to\{0,1\}^*$$" {
   text.md {
@@ -33,6 +65,34 @@
       "$$": punctuation.md
       "f \in \{0,1\}^*\to\{0,1\}^*"
       "$$": punctuation.md
+    }
+  }
+}
+
+@math/2b-1
+"\\[f \in \{0,1\}^*\to\{0,1\}^*\\]" {
+  text.md {
+    block.math.markup.md {
+      "\\[": punctuation.definition.string.begin.latex
+      "f \in \{0,1\}^*\to\{0,1\}^*"
+      "\\]": punctuation.definition.string.end.latex
+    }
+  }
+}
+
+@math/2b-2
+"\begin{equation}f \in \{0,1\}^*\to\{0,1\}^*\end{equation}" {
+  text.md {
+    block.math.markup.md {
+      "\begin": support.function.be.latex
+      "{": punctuation.definition.arguments.begin.latex
+      "equation": variable.parameter.function.latex
+      "}": punctuation.definition.arguments.end.latex
+      "f \in \{0,1\}^*\to\{0,1\}^*"
+      "\end": support.function.be.latex
+      "{": punctuation.definition.arguments.begin.latex
+      "equation": variable.parameter.function.latex
+      "}": punctuation.definition.arguments.end.latex
     }
   }
 }


### PR DESCRIPTION
As discussed in #189, the following notations are added to math-block notation:

```tex
\[
  a = \sum \frac 1 i
\]

\begin{equation}
  a = \sum \frac 1 i
\end{equation}

\begin{equation*}
  a = \sum \frac 1 i
\end{equation*}
```