### PR TITLE
Add classes for vertical and horizontal lines in GitHub tables

### DIFF
--- a/grammars/language-markdown.json
+++ b/grammars/language-markdown.json
@@ -877,13 +877,13 @@
                   "match": "(\\|)(?: ?)(:?)(-+)(:?)(?: ?)(?=\\|| |$)",
                   "captures": {
                     "1": {
-                      "name": "punctuation.md"
+                      "name": "vertical.punctuation.md"
                     },
                     "2": {
                       "name": "alignment.punctuation.md"
                     },
                     "3": {
-                      "name": "punctuation.md"
+                      "name": "horizontal.punctuation.md"
                     },
                     "4": {
                       "name": "alignment.punctuation.md"
@@ -893,7 +893,7 @@
               ]
             },
             "2": {
-              "name": "punctuation.md"
+              "name": "vertical.punctuation.md"
             }
           }
         },
@@ -902,13 +902,13 @@
           "match": "^(\\|)(?= )(.+)$",
           "captures": {
             "1": {
-              "name": "punctuation.md"
+              "name": "vertical.punctuation.md"
             },
             "2": {
               "patterns": [
                 {
                   "match": "(?<= )\\|(?=$| )",
-                  "name": "punctuation.md"
+                  "name": "vertical.punctuation.md"
                 },
                 {
                   "include": "#inlines-in-blocks"

--- a/grammars/repositories/flavors/github-blocks.cson
+++ b/grammars/repositories/flavors/github-blocks.cson
@@ -11,13 +11,13 @@ patterns: [
           {
             match: '(\\|)(?: ?)(:?)(-+)(:?)(?: ?)(?=\\|| |$)'
             captures:
-              1: name: 'punctuation.md'
+              1: name: 'vertical.punctuation.md'
               2: name: 'alignment.punctuation.md'
-              3: name: 'punctuation.md'
+              3: name: 'horizontal.punctuation.md'
               4: name: 'alignment.punctuation.md'
           }
         ]
-      2: name: 'punctuation.md'
+      2: name: 'vertical.punctuation.md'
   }
 
   # Table: data
@@ -25,12 +25,12 @@ patterns: [
     name: 'table.storage.md'
     match: '^(\\|)(?= )(.+)$'
     captures:
-      1: name: 'punctuation.md'
+      1: name: 'vertical.punctuation.md'
       2:
         patterns: [
           {
             match: '(?<= )\\|(?=$| )'
-            name: 'punctuation.md'
+            name: 'vertical.punctuation.md'
           }
           {
             include: '#inlines-in-blocks'

--- a/spec/fixtures/flavors/github/tables.ass
+++ b/spec/fixtures/flavors/github/tables.ass
@@ -2,13 +2,13 @@
 "| one | two | three |" {
   text.md {
     table.storage.md {
-      "|": punctuation.md
+      "|": vertical.punctuation.md
       " one "
-      "|": punctuation.md
+      "|": vertical.punctuation.md
       " two "
-      "|": punctuation.md
+      "|": vertical.punctuation.md
       " three "
-      "|": punctuation.md
+      "|": vertical.punctuation.md
     }
   }
 }
@@ -20,11 +20,11 @@
 "| one | two | three" {
   text.md {
     table.storage.md {
-      "|": punctuation.md
+      "|": vertical.punctuation.md
       " one "
-      "|": punctuation.md
+      "|": vertical.punctuation.md
       " two "
-      "|": punctuation.md
+      "|": vertical.punctuation.md
       " three"
     }
   }
@@ -37,19 +37,19 @@
 "| --- | --- | --- |" {
   text.md {
     table.storage.md {
-      "|": punctuation.md
+      "|": vertical.punctuation.md
       " "
-      "---": punctuation.md
+      "---": horizontal.punctuation.md
       " "
-      "|": punctuation.md
+      "|": vertical.punctuation.md
       " "
-      "---": punctuation.md
+      "---": horizontal.punctuation.md
       " "
-      "|": punctuation.md
+      "|": vertical.punctuation.md
       " "
-      "---": punctuation.md
+      "---": horizontal.punctuation.md
       " "
-      "|": punctuation.md
+      "|": vertical.punctuation.md
     }
   }
 }
@@ -61,17 +61,17 @@
 "| --- | --- | ---" {
   text.md {
     table.storage.md {
-      "|": punctuation.md
+      "|": vertical.punctuation.md
       " "
-      "---": punctuation.md
+      "---": horizontal.punctuation.md
       " "
-      "|": punctuation.md
+      "|": vertical.punctuation.md
       " "
-      "---": punctuation.md
+      "---": horizontal.punctuation.md
       " "
-      "|": punctuation.md
+      "|": vertical.punctuation.md
       " "
-      "---": punctuation.md
+      "---": horizontal.punctuation.md
     }
   }
 }
@@ -80,12 +80,12 @@
 "|---|---|---" {
   text.md {
     table.storage.md {
-      "|": punctuation.md
-      "---": punctuation.md
-      "|": punctuation.md
-      "---": punctuation.md
-      "|": punctuation.md
-      "---": punctuation.md
+      "|": vertical.punctuation.md
+      "---": horizontal.punctuation.md
+      "|": vertical.punctuation.md
+      "---": horizontal.punctuation.md
+      "|": vertical.punctuation.md
+      "---": horizontal.punctuation.md
     }
   }
 }
@@ -94,19 +94,19 @@
 "|:--- |:---:| ---:|" {
   text.md {
     table.storage.md {
-      "|": punctuation.md
+      "|": vertical.punctuation.md
       ":": alignment.punctuation.md
-      "---": punctuation.md
+      "---": horizontal.punctuation.md
       " "
-      "|": punctuation.md
+      "|": vertical.punctuation.md
       ":": alignment.punctuation.md
-      "---": punctuation.md
+      "---": horizontal.punctuation.md
       ":": alignment.punctuation.md
-      "|": punctuation.md
+      "|": vertical.punctuation.md
       " "
-      "---": punctuation.md
+      "---": horizontal.punctuation.md
       ":": alignment.punctuation.md
-      "|": punctuation.md
+      "|": vertical.punctuation.md
     }
   }
 }
@@ -115,23 +115,23 @@
 "| :-- | :-: | --: |" {
   text.md {
     table.storage.md {
-      "|": punctuation.md
+      "|": vertical.punctuation.md
       " "
       ":": alignment.punctuation.md
-      "--": punctuation.md
+      "--": horizontal.punctuation.md
       " "
-      "|": punctuation.md
+      "|": vertical.punctuation.md
       " "
       ":": alignment.punctuation.md
-      "-": punctuation.md
+      "-": horizontal.punctuation.md
       ":": alignment.punctuation.md
       " "
-      "|": punctuation.md
+      "|": vertical.punctuation.md
       " "
-      "--": punctuation.md
+      "--": horizontal.punctuation.md
       ":": alignment.punctuation.md
       " "
-      "|": punctuation.md
+      "|": vertical.punctuation.md
     }
   }
 }
@@ -140,7 +140,7 @@
 "| _one_ | **two** | [three] |" {
   text.md {
     table.storage.md {
-      "|": punctuation.md
+      "|": vertical.punctuation.md
       " "
       "_one_" {
         emphasis.italic.markup.md {
@@ -150,7 +150,7 @@
         }
       }
       " "
-      "|": punctuation.md
+      "|": vertical.punctuation.md
       " "
       "**two**" {
         strong.emphasis.bold.markup.md {
@@ -160,7 +160,7 @@
         }
       }
       " "
-      "|": punctuation.md
+      "|": vertical.punctuation.md
       " "
       "[three]" {
         label.link.string.md {
@@ -170,7 +170,7 @@
         }
       }
       " "
-      "|": punctuation.md
+      "|": vertical.punctuation.md
     }
   }
 }
@@ -179,13 +179,13 @@
 "| --- | --- | three |" {
   text.md {
     table.storage.md {
-      "|": punctuation.md
+      "|": vertical.punctuation.md
       " --- "
-      "|": punctuation.md
+      "|": vertical.punctuation.md
       " --- "
-      "|": punctuation.md
+      "|": vertical.punctuation.md
       " three "
-      "|": punctuation.md
+      "|": vertical.punctuation.md
     }
   }
 }
@@ -194,13 +194,13 @@
 "| name | e-mail | address |" {
   text.md {
     table.storage.md {
-      "|": punctuation.md
+      "|": vertical.punctuation.md
       " name "
-      "|": punctuation.md
+      "|": vertical.punctuation.md
       " e-mail "
-      "|": punctuation.md
+      "|": vertical.punctuation.md
       " address "
-      "|": punctuation.md
+      "|": vertical.punctuation.md
     }
   }
 }


### PR DESCRIPTION
This pull request adds classes for the vertical and horizontal lines in GitHub flavor tables.

It adds these two classes:

1. To the `|` punctuation in the tables it adds `.vertical` class.
2. To the `-` punctuation in the tables it adds `.horizontal` class. The string of `-`s is still one unit. I split them up at first, but apparently hit a token number limit with really wide tables.

I added these to help myself in styling tables.