### PR TITLE
Add support for Stata code blocks

### DIFF
--- a/grammars/fixtures/fenced-code.cson
+++ b/grammars/fixtures/fenced-code.cson
@@ -70,6 +70,7 @@ list: [
   { pattern:'scss', include:'source.css.scss', contentName:'source.embedded.css.scss' }
   { pattern:'sh|bash', include:'source.shell', contentName:'source.embedded.shell' }
   { pattern:'sql' }
+  { pattern:'stata' }
   { pattern:'swift' }
   { pattern:'xml', include:'text.xml', contentName:'text.embedded.xml' }
 

--- a/grammars/language-markdown.json
+++ b/grammars/language-markdown.json
@@ -3866,6 +3866,46 @@
           ]
         },
         {
+          "begin": "^\\s*([`~]{3,})\\s*(\\{?)((?:\\.?)(?:stata))(?=( |$|{))\\s*(\\{?)([^`\\{\\}]*)(\\}?)$",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.md"
+            },
+            "2": {
+              "name": "punctuation.md"
+            },
+            "3": {
+              "name": "language.constant.md"
+            },
+            "5": {
+              "name": "punctuation.md"
+            },
+            "6": {
+              "patterns": [
+                {
+                  "include": "#special-attribute-elements"
+                }
+              ]
+            },
+            "7": {
+              "name": "punctuation.md"
+            }
+          },
+          "end": "^\\s*(\\1)$",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.md"
+            }
+          },
+          "name": "fenced.code.md",
+          "contentName": "source.embedded.stata",
+          "patterns": [
+            {
+              "include": "source.stata"
+            }
+          ]
+        },
+        {
           "begin": "^\\s*([`~]{3,})\\s*(\\{?)((?:\\.?)(?:swift))(?=( |$|{))\\s*(\\{?)([^`\\{\\}]*)(\\}?)$",
           "beginCaptures": {
             "1": {


### PR DESCRIPTION
This embeds [language-stata](https://atom.io/packages/language-stata) in code blocks that start with ```stata. I added the single line for `{ pattern:'stata' }` in ``fenced-code.cson`` and then ran ``language-markdown:compile-grammar-and-reload``.