### PR TITLE
added firstLineMatch for automatic recognition

### DIFF
--- a/grammars/language-markdown.json
+++ b/grammars/language-markdown.json
@@ -13,6 +13,7 @@
     "emdee",
     "spec"
   ],
+  "firstLineMatch": "^(-{3}|#{1,5}\\s+\\w)",
   "patterns": [
     {
       "include": "#blocks"

--- a/grammars/language-markdown.json
+++ b/grammars/language-markdown.json
@@ -13,7 +13,7 @@
     "emdee",
     "spec"
   ],
-  "firstLineMatch": "^(-{3}|#{1,5}\\s+\\w)",
+  "firstLineMatch": "^(-{3}|#{1,6}\\s+\\w)",
   "patterns": [
     {
       "include": "#blocks"


### PR DESCRIPTION
added firstLineMatch for automatic recognition of
- a yaml header (3 dashes)
- a heading (1-5 hashes followed by an optional whitespace and at least one word character)

what does not work:
underlined headers as they're more than one line