### PR TITLE
auto increment of ordered lists is configurable

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -21,7 +21,7 @@ module.exports = {
         title: 'Increment Ordered List Items',
         description: 'Automatically increment a new list-item after the current(non-empty) one when pressing <kbd>ENTER</kbd>',
         type: 'boolean',
-        default: false
+        default: true
     },
 
     disableLanguageGfm: {

--- a/lib/main.js
+++ b/lib/main.js
@@ -17,6 +17,13 @@ module.exports = {
       default: true
     },
 
+    autoIncrementListItems: {
+        title: 'Increment Ordered List Items',
+        description: 'Automatically increment a new list-item after the current(non-empty) one when pressing <kbd>ENTER</kbd>',
+        type: 'boolean',
+        default: false
+    },
+
     disableLanguageGfm: {
       title: 'Disable language-gfm',
       description: 'Disable the default `language-gfm` package as this package is intended as its replacement',
@@ -144,7 +151,10 @@ module.exports = {
             if (typeOfList === 'ordered') {
               const length = text.length
               const punctuation = text.match(/[^\d]+/)
-              const value = parseInt(text) + 1
+              var value = parseInt(text)
+              if (atom.config.get('language-markdown.autoIncrementListItems')) {
+                  value = value + 1
+              }
               text = value + punctuation
               if (text.length < length) {
                 for (let j = 0; j < text.length - length + 1; j++) {


### PR DESCRIPTION
Option added to enable/disable automatic increment of ordered list items. 

When adding a newline after a non-empty ordered list-item, I'm getting an incremented list-item. I see the benefit of doing that, however, I think it would be a small 'nice to have' feature to have this behavior configurable.

Let me know what you think!