### PR TITLE
[WIP] Add support for Pandoc's generic raw attributes

### DIFF
--- a/grammars/language-markdown.json
+++ b/grammars/language-markdown.json
@@ -49,6 +49,9 @@
           "include": "#rmarkdown"
         },
         {
+          "include": "#pandoc-raw-attribute-blocks"
+        },
+        {
           "include": "#fenced-code-blocks"
         },
         {
@@ -66,6 +69,9 @@
       "patterns": [
         {
           "include": "#escapes"
+        },
+        {
+          "include": "#pandoc-raw-attribute-inlines"
         },
         {
           "include": "#code"
@@ -1191,6 +1197,134 @@
               "patterns": [
                 {
                   "include": "text.tex.latex"
+                }
+              ]
+            },
+            "3": {
+              "name": "punctuation.md"
+            }
+          }
+        }
+      ]
+    },
+    "pandoc-raw-attribute-blocks": {
+      "patterns": [
+        {
+          "begin": "^\\s{0,3}([`~]{3,})\\s*\\{\\s*=(latex|beamer)\\s*\\}\\s*?$",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.md"
+            }
+          },
+          "end": "^\\s{0,3}(\\1)$",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.md"
+            }
+          },
+          "name": "fenced.rawattribute.md",
+          "contentName": "source.embedded.latex",
+          "patterns": [
+            {
+              "include": "text.tex.latex"
+            }
+          ]
+        },
+        {
+          "begin": "^\\s{0,3}([`~]{3,})\\s*\\{\\s*=(openxml|opendocument)\\s*\\}\\s*?$",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.md"
+            }
+          },
+          "end": "^\\s{0,3}(\\1)$",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.md"
+            }
+          },
+          "name": "fenced.rawattribute.md",
+          "contentName": "source.embedded.xml",
+          "patterns": [
+            {
+              "include": "text.xml"
+            }
+          ]
+        },
+        {
+          "begin": "^\\s{0,3}([`~]{3,})\\s*\\{\\s*=(html(?:4|5)?)\\s*\\}\\s*?$",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.md"
+            }
+          },
+          "end": "^\\s{0,3}(\\1)$",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.md"
+            }
+          },
+          "name": "fenced.rawattribute.md",
+          "contentName": "source.embedded.html",
+          "patterns": [
+            {
+              "include": "text.html.basic"
+            }
+          ]
+        }
+      ]
+    },
+    "pandoc-raw-attribute-inlines": {
+      "patterns": [
+        {
+          "match": "(?<!`)(`+)(?!`)(.+?)(?<!`)(\\1)(?!`)\\{\\s*=(latex|beamer)\\s*\\}",
+          "name": "code.raw.markup.md",
+          "captures": {
+            "1": {
+              "name": "punctuation.md"
+            },
+            "2": {
+              "patterns": [
+                {
+                  "include": "text.tex.latex"
+                }
+              ]
+            },
+            "3": {
+              "name": "punctuation.md"
+            }
+          }
+        },
+        {
+          "match": "(?<!`)(`+)(?!`)(.+?)(?<!`)(\\1)(?!`)\\{\\s*=(html(?:4|5)?)\\s*\\}",
+          "name": "code.raw.markup.md",
+          "captures": {
+            "1": {
+              "name": "punctuation.md"
+            },
+            "2": {
+              "patterns": [
+                {
+                  "include": "text.html.basic"
+                }
+              ]
+            },
+            "3": {
+              "name": "punctuation.md"
+            }
+          }
+        },
+        {
+          "match": "(?<!`)(`+)(?!`)(.+?)(?<!`)(\\1)(?!`)\\{\\s*=(openxml|opendocument)\\s*\\}",
+          "name": "code.raw.markup.md",
+          "captures": {
+            "1": {
+              "name": "punctuation.md"
+            },
+            "2": {
+              "patterns": [
+                {
+                  "include": "text.xml"
                 }
               ]
             },

--- a/grammars/repositories/flavors/pandoc-raw-attribute-blocks.cson
+++ b/grammars/repositories/flavors/pandoc-raw-attribute-blocks.cson
@@ -1,0 +1,39 @@
+key: 'pandoc-raw-attribute-blocks'
+patterns: [
+
+  # See https://pandoc.org/MANUAL.html#generic-raw-attribute
+  {
+    begin: '^\\s{0,3}([`~]{3,})\\s*\\{\\s*=(latex|beamer)\\s*\\}\\s*?$'
+    beginCaptures:
+      1: name: 'punctuation.md'
+    end: '^\\s{0,3}(\\1)$'
+    endCaptures:
+      1: name: 'punctuation.md'
+    name: 'fenced.rawattribute.md'
+    contentName: 'source.embedded.latex'
+    patterns: [{ include: 'text.tex.latex' }]
+  }
+  {
+    begin: '^\\s{0,3}([`~]{3,})\\s*\\{\\s*=(openxml|opendocument)\\s*\\}\\s*?$'
+    beginCaptures:
+      1: name: 'punctuation.md'
+    end: '^\\s{0,3}(\\1)$'
+    endCaptures:
+      1: name: 'punctuation.md'
+    name: 'fenced.rawattribute.md'
+    contentName: 'source.embedded.xml'
+    patterns: [{ include: 'text.xml' }]
+  }
+  {
+    begin: '^\\s{0,3}([`~]{3,})\\s*\\{\\s*=(html(?:4|5)?)\\s*\\}\\s*?$'
+    beginCaptures:
+      1: name: 'punctuation.md'
+    end: '^\\s{0,3}(\\1)$'
+    endCaptures:
+      1: name: 'punctuation.md'
+    name: 'fenced.rawattribute.md'
+    contentName: 'source.embedded.html'
+    patterns: [{ include: 'text.html.basic' }]
+  }
+
+]

--- a/grammars/repositories/flavors/pandoc-raw-attribute-inlines.cson
+++ b/grammars/repositories/flavors/pandoc-raw-attribute-inlines.cson
@@ -1,0 +1,30 @@
+key: 'pandoc-raw-attribute-inlines'
+patterns: [
+
+  # See https://pandoc.org/MANUAL.html#generic-raw-attribute
+  {
+    match: '(?<!`)(`+)(?!`)(.+?)(?<!`)(\\1)(?!`)\\{\\s*=(latex|beamer)\\s*\\}'
+    name: 'code.raw.markup.md'
+    captures:
+      1: name: 'punctuation.md'
+      2: patterns: [{ include: 'text.tex.latex' }]
+      3: name: 'punctuation.md'
+  }
+  {
+    match: '(?<!`)(`+)(?!`)(.+?)(?<!`)(\\1)(?!`)\\{\\s*=(html(?:4|5)?)\\s*\\}'
+    name: 'code.raw.markup.md'
+    captures:
+      1: name: 'punctuation.md'
+      2: patterns: [{ include: 'text.html.basic' }]
+      3: name: 'punctuation.md'
+  }
+  {
+    match: '(?<!`)(`+)(?!`)(.+?)(?<!`)(\\1)(?!`)\\{\\s*=(openxml|opendocument)\\s*\\}'
+    name: 'code.raw.markup.md'
+    captures:
+      1: name: 'punctuation.md'
+      2: patterns: [{ include: 'text.xml' }]
+      3: name: 'punctuation.md'
+  }
+
+]

--- a/grammars/repositories/markdown.cson
+++ b/grammars/repositories/markdown.cson
@@ -33,6 +33,7 @@ repository:
       { include: '#lists' }
       { include: '#quotes' }
       { include: '#rmarkdown' }
+      { include: '#pandoc-raw-attribute-blocks' }
       { include: '#fenced-code-blocks' }
       { include: '#fenced-code' }
       { include: '#github-blocks' }
@@ -41,6 +42,7 @@ repository:
   inlines:
     patterns: [
       { include: '#escapes' }
+      { include: '#pandoc-raw-attribute-inlines' }
       { include: '#code' }
       { include: '#entities' }
       { include: '#links' }


### PR DESCRIPTION
See #225 and https://pandoc.org/MANUAL.html#generic-raw-attribute.

Pandoc added support for Inline and Block raw attributes with version 2.0.

![image](https://user-images.githubusercontent.com/15164633/41609046-ea80666e-73b7-11e8-832c-956850d40ee8.png)

LaTeX still isn't included perfectly. It might have something to do with the [injectionsSelector](https://github.com/area/language-latex/blob/2447b74978e2584e610e14d956c1c41cc1b8c7ab/grammars/latex.cson#L14) property of the LaTeX grammars file.

With this branch of language-markdown:
![image](https://user-images.githubusercontent.com/15164633/41609111-0954506e-73b8-11e8-9090-79f84e8ba72a.png)

With language-latex highlighting:
![image](https://user-images.githubusercontent.com/15164633/41609162-2331b562-73b8-11e8-9fcd-304a42051159.png)

@Aerijo Your [gist](https://gist.github.com/Aerijo/b8c82d647db783187804e86fa0a604a1#injections) detailing injections is super helpful, and I see you've also worked on the language-latex package. Do you happen to quickly see the issue? 

This is the relevant portion of the grammars file
```cson
  {
    begin: '^\\s{0,3}([`~]{3,})\\s*\\{\\s*=(latex|beamer)\\s*\\}\\s*?$'
    beginCaptures:
      1: name: 'punctuation.md'
    end: '^\\s{0,3}(\\1)$'
    endCaptures:
      1: name: 'punctuation.md'
    name: 'fenced.rawattribute.md'
    contentName: 'source.embedded.latex'
    patterns: [{ include: 'text.tex.latex' }]
  }
```

The scopes for the incorrectly-colored `\begin{tabular}` are:
```
Scopes at Cursor

text.md
fenced.rawattribute.md
source.embedded.latex
meta.function.environment.general.latex
```

and the scopes for the correctly-colored `begin{center}` are:
```
Scopes at Cursor

text.md
fenced.rawattribute.md
source.embedded.latex
meta.function.environment.general.latex
support.function.be.latex
```

When the file's scope is set to `text.tex.latex`, the scopes for `\begin{tabular}` are:
```
text.tex.latex
meta.function.environment.general.latex
meta.function.environment.tabular.latex
support.function.be.latex
```

I don't understand how the scopes are so different for the same text.