### PR TITLE
Prevent matching of invalid HTML tags

### DIFF
--- a/grammars/language-markdown.json
+++ b/grammars/language-markdown.json
@@ -1724,6 +1724,10 @@
     "html": {
       "patterns": [
         {
+          "match": "<(?![a-zA-z0-9!/])",
+          "name": "text.md"
+        },
+        {
           "include": "text.html.basic"
         }
       ]

--- a/grammars/repositories/inlines/html.cson
+++ b/grammars/repositories/inlines/html.cson
@@ -1,4 +1,8 @@
 key: 'html'
 patterns: [
+  {
+    match: '<(?![a-zA-z0-9!/])'
+    name: 'text.md'
+  }
   { include: 'text.html.basic' }
 ]


### PR DESCRIPTION
Here's a simple idea to fix https://github.com/burodepeper/language-markdown/issues/178.

![image](https://user-images.githubusercontent.com/15164633/46747570-a8d14500-cc7f-11e8-8b93-2378c9174824.png)
