### PR TITLE
reproduce leading whitespaces of prev line when adding new list items

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -108,6 +108,7 @@ module.exports = {
         const previousLine = editor.getTextInRange(previousRowRange)
         let { tokens } = grammar.tokenizeLine(previousLine)
         tokens.reverse()
+        let leadingWhitespaces = 0
         for (const token of tokens) {
           let isPunctuation = false
           let isListItem = false
@@ -146,6 +147,10 @@ module.exports = {
             }
           }
 
+          if (!isListItem) {
+              leadingWhitespaces = token.value.match(/^ */)[0].length
+          }
+
           if (isListItem && typeOfList !== 'definition') {
             let text = token.value
             if (typeOfList === 'ordered') {
@@ -164,7 +169,7 @@ module.exports = {
             } else {
               text = text.replace('x', ' ')
             }
-            editor.insertText(text + '')
+            editor.insertText(text + ' '.repeat(leadingWhitespaces))
             break
           }
         }

--- a/spec/new-list-item-spec.coffee
+++ b/spec/new-list-item-spec.coffee
@@ -1,0 +1,59 @@
+describe 'Add new list items', ->
+  editor = null
+
+  beforeEach ->
+    waitsForPromise ->
+      atom.workspace.open()
+      atom.packages.activatePackage('language-markdown')
+    runs ->
+      # with `buildTextEditor` the `onDidInsertText` event will never be emitted
+      editor = atom.workspace.getActiveTextEditor()
+      editor.setGrammar(atom.grammars.grammarForScopeName('text.md'))
+
+  it 'ignores `setCursorBufferPosition`', ->
+    editor.setText('0123')
+    editor.setCursorBufferPosition(0, 4)
+    expect(editor.getCursorBufferPosition().column).toBe(0)
+    editor.insertText('x')
+    expect(editor.getText()).toBe('x0123')
+
+  it 'updates cursor position properly on `insertText`', ->
+    editor.insertText('0123')
+    expect(editor.getCursorBufferPosition().column).toBe(4)
+    editor.insertText('x')
+    expect(editor.getCursorBufferPosition().column).toBe(5)
+    expect(editor.getText()).toBe('0123x')
+
+  it 'should not create new list item on newline when disabled', ->
+    atom.config.set('language-markdown.addListItems', false)
+    expect(atom.config.get('language-markdown.addListItems')).toBe(false)
+    editor.insertText('- item')
+    editor.insertNewline()
+    expect(editor.getText()).toBe('- item\n')
+
+  it 'should create new list item on newline', ->
+    editor.insertText('- item')
+    editor.insertText('\n')
+    expect(editor.getText()).toBe('- item\n- ')
+
+  it 'should reproduce whitespaces between list item and content', ->
+    editor.insertText('-   item')
+    editor.insertText('\n')
+    expect(editor.getText()).toBe('-   item\n-   ')
+
+  it 'should reproduce tabs between list item and content', ->
+    editor.insertText('-\titem')
+    editor.insertText('\n')
+    expect(editor.getText()).toBe('-\titem\n-\t')
+
+  it 'should work with autoindent', ->
+    editor.insertText('    - item')
+    editor.autoIndent = true  # is there a better way to activate this?
+    editor.insertText('\n')
+    expect(editor.getText()).toBe('    - item\n    - ')
+
+  it 'should reproduce whitespaces in nested lists, with help from autoindent', ->
+    editor.insertText('-  item 1\n  -  item 2')
+    editor.autoIndent = true  # is there a better way to activate this?
+    editor.insertText('\n')
+    expect(editor.getText()).toBe('-  item 1\n  -  item 2\n  -  ')


### PR DESCRIPTION
in lists with more than one whitespace between list marker "add new list items" will inconveniently create list items with only one space. example, where `_` marks cursor position after creating new item:
```
-   item1
-   item2
- _
```

this pr adds whitespaces in new item like so:
```
-   item1
-   item2
-   _
```

this may also fix #238 