### PR TITLE
Highlight link references with variable whitespace

### DIFF
--- a/grammars/language-markdown.json
+++ b/grammars/language-markdown.json
@@ -2027,34 +2027,36 @@
           }
         },
         {
-          "name": "reference.link.markup.md",
-          "match": "(?x) ((?:\\[)(?:[^\\[\\]]*)(?:\\])) (:) (?:\\s) ([^ [:cntrl:]]+) (?:(?:\\s)((?:\")(?:.*?)(?:\")))? (?:(?:\\s)(\\{[[:ascii:]]*\\}))?",
+          "match": "(?x) ^ \\s* ( ((?:\\[)(?:[^\\[\\]]*)(?:\\])) (:) (?:\\s*) ([^ [:cntrl:]]+) (?:(?:\\s)((?:\")(?:.*?)(?:\")))? (?:(?:\\s)(\\{[[:ascii:]]*\\}))? )",
           "captures": {
             "1": {
+              "name": "reference.link.markup.md"
+            },
+            "2": {
               "patterns": [
                 {
                   "include": "#link-label"
                 }
               ]
             },
-            "2": {
+            "3": {
               "name": "punctuation.md"
             },
-            "3": {
+            "4": {
               "patterns": [
                 {
                   "include": "#link-destination"
                 }
               ]
             },
-            "4": {
+            "5": {
               "patterns": [
                 {
                   "include": "#link-title"
                 }
               ]
             },
-            "5": {
+            "6": {
               "patterns": [
                 {
                   "include": "#special-attributes"

--- a/grammars/repositories/inlines/links.cson
+++ b/grammars/repositories/inlines/links.cson
@@ -227,21 +227,24 @@ patterns: [
   # [ref]: /uri
   # [ref]: /uri "title"
   {
-    name: 'reference.link.markup.md'
     match: '(?x)
-      ((?:\\[)(?:[^\\[\\]]*)(?:\\]))
-      (:)
-      (?:\\s)
-      ([^ [:cntrl:]]+)
-      (?:(?:\\s)((?:")(?:.*?)(?:")))?
-      (?:(?:\\s)(\\{[[:ascii:]]*\\}))?
+      ^ \\s*
+      (
+        ((?:\\[)(?:[^\\[\\]]*)(?:\\]))
+        (:)
+        (?:\\s*)
+        ([^ [:cntrl:]]+)
+        (?:(?:\\s)((?:")(?:.*?)(?:")))?
+        (?:(?:\\s)(\\{[[:ascii:]]*\\}))?
+      )
     '
     captures:
-      1: patterns: [{ include: '#link-label' }]
-      2: name: 'punctuation.md'
-      3: patterns: [{ include: '#link-destination' }]
-      4: patterns: [{ include: '#link-title' }]
-      5: patterns: [{ include: '#special-attributes' }]
+      1: name: 'reference.link.markup.md'
+      2: patterns: [{ include: '#link-label' }]
+      3: name: 'punctuation.md'
+      4: patterns: [{ include: '#link-destination' }]
+      5: patterns: [{ include: '#link-title' }]
+      6: patterns: [{ include: '#special-attributes' }]
   }
 
   # [[interlink]]


### PR DESCRIPTION
Both of the following are legal syntax for declaring link references:

~~~markdown
[Link]:https://github.com/
[Link]:  https://github.com/
~~~

However, the `language-markdown` grammar incorrectly accepts only 1 space between the colon and URL:

~~~markdown
[Link]: https://github.com/
~~~

This PR fixes that.